### PR TITLE
fix(sync): fail fast on dirty working tree and always clean up failed rebase state

### DIFF
--- a/crates/pearls-cli/src/commands/status.rs
+++ b/crates/pearls-cli/src/commands/status.rs
@@ -4,10 +4,11 @@
 //!
 //! Displays project health checks and a "land the plane" checklist.
 
+use crate::git::working_tree_is_clean;
 use crate::output_mode::is_json_output;
 use anyhow::Result;
 use chrono::{Duration, Utc};
-use git2::{BranchType, Repository, StatusOptions};
+use git2::{BranchType, Repository};
 use pearls_core::{IssueGraph, Status, Storage};
 use std::path::Path;
 
@@ -134,10 +135,7 @@ struct GitStatusSummary {
 
 fn collect_git_status() -> Result<GitStatusSummary> {
     let repo = Repository::discover(".")?;
-    let mut options = StatusOptions::new();
-    options.include_untracked(true).recurse_untracked_dirs(true);
-    let statuses = repo.statuses(Some(&mut options))?;
-    let is_clean = statuses.is_empty();
+    let is_clean = working_tree_is_clean(&repo)?;
 
     let sync_status = resolve_sync_status(&repo);
 

--- a/crates/pearls-cli/src/git.rs
+++ b/crates/pearls-cli/src/git.rs
@@ -1,0 +1,48 @@
+// Rust guideline compliant 2026-02-12
+
+//! Shared Git helpers for CLI commands.
+
+use anyhow::Result;
+use git2::{Repository, StatusOptions};
+
+/// Returns whether the repository working tree is clean.
+///
+/// A clean working tree means there are no staged, unstaged, or untracked changes.
+///
+/// # Arguments
+///
+/// * `repo` - The Git repository to inspect
+///
+/// # Returns
+///
+/// `true` when no changes are detected, otherwise `false`.
+///
+/// # Errors
+///
+/// Returns an error if repository status cannot be read.
+pub(crate) fn working_tree_is_clean(repo: &Repository) -> Result<bool> {
+    let mut options = StatusOptions::new();
+    options.include_untracked(true).recurse_untracked_dirs(true);
+    let statuses = repo.statuses(Some(&mut options))?;
+    Ok(statuses.is_empty())
+}
+
+/// Ensures the repository has no local changes before a sync operation.
+///
+/// # Arguments
+///
+/// * `repo` - The Git repository to inspect
+///
+/// # Returns
+///
+/// Ok when the repository is clean.
+///
+/// # Errors
+///
+/// Returns an error when the working tree contains local changes.
+pub(crate) fn ensure_clean_working_tree_for_sync(repo: &Repository) -> Result<()> {
+    if !working_tree_is_clean(repo)? {
+        anyhow::bail!("Working directory has changes. Commit or stash before sync.");
+    }
+    Ok(())
+}

--- a/crates/pearls-cli/src/lib.rs
+++ b/crates/pearls-cli/src/lib.rs
@@ -5,6 +5,7 @@
 //! This library exposes the CLI modules for use in tests and external code.
 
 pub mod commands;
+pub mod git;
 pub mod output;
 pub mod output_mode;
 pub mod progress;

--- a/crates/pearls-cli/src/main.rs
+++ b/crates/pearls-cli/src/main.rs
@@ -7,6 +7,7 @@
 use clap::Parser;
 
 pub mod commands;
+pub mod git;
 pub mod output;
 pub mod output_mode;
 pub mod progress;


### PR DESCRIPTION
fix(sync): fail fast on dirty working tree and always clean up failed rebase state

This PR fixes #1 , a `prl sync` reliability issue where sync could leave Git in a hanging rebase state when invoked in problematic local conditions. It adds a preflight clean-tree guard, defensive rebase abort logic, and regression tests for staged/unstaged and conflict paths.
