### PR TITLE
Add configurable max priority across core, CLI, and MCP

### DIFF
--- a/crates/pearls-cli/src/commands/create.rs
+++ b/crates/pearls-cli/src/commands/create.rs
@@ -16,7 +16,7 @@ use std::path::Path;
 ///
 /// * `title` - The Pearl title
 /// * `description` - Optional description
-/// * `priority` - Optional priority (0-4)
+/// * `priority` - Optional priority (0-max_priority)
 /// * `labels` - Optional labels
 /// * `author` - Optional author (defaults to Git config or system username)
 ///
@@ -68,8 +68,8 @@ pub fn execute(
     }
 
     if let Some(p) = priority {
-        if p > 4 {
-            anyhow::bail!("Priority must be 0-4, got {}", p);
+        if p > config.max_priority {
+            anyhow::bail!("Priority must be 0-{}, got {}", config.max_priority, p);
         }
         pearl.priority = p;
     } else {
@@ -105,7 +105,7 @@ pub fn execute(
         if !pearl.description.is_empty() {
             println!("  Description: {}", pearl.description);
         }
-        if pearl.priority != 2 {
+        if pearl.priority != config.default_priority {
             println!("  Priority: {}", pearl.priority);
         }
         if !pearl.labels.is_empty() {

--- a/crates/pearls-cli/src/commands/import.rs
+++ b/crates/pearls-cli/src/commands/import.rs
@@ -6,7 +6,7 @@
 
 use crate::output_mode::is_json_output;
 use anyhow::Result;
-use pearls_core::{Pearl, Storage};
+use pearls_core::{Config, Pearl, Storage};
 use std::io::BufRead;
 use std::path::{Path, PathBuf};
 
@@ -33,6 +33,7 @@ pub fn import_beads(path: String) -> Result<()> {
     if !pearls_dir.exists() {
         anyhow::bail!("Pearls repository not initialized. Run 'prl init' first.");
     }
+    let config = Config::load(pearls_dir)?;
 
     let beads_path = PathBuf::from(path);
     if !beads_path.exists() {
@@ -61,6 +62,14 @@ pub fn import_beads(path: String) -> Result<()> {
                         "Warning: Skipping invalid Pearl on line {}: {}",
                         idx + 1,
                         err
+                    );
+                } else if pearl.priority > config.max_priority {
+                    skipped += 1;
+                    eprintln!(
+                        "Warning: Skipping Pearl on line {}: priority {} exceeds configured max_priority {}",
+                        idx + 1,
+                        pearl.priority,
+                        config.max_priority
                     );
                 } else {
                     pearls.push(pearl);

--- a/crates/pearls-cli/src/commands/update.rs
+++ b/crates/pearls-cli/src/commands/update.rs
@@ -7,7 +7,7 @@
 
 use crate::output_mode::is_json_output;
 use anyhow::Result;
-use pearls_core::Storage;
+use pearls_core::{Config, Storage};
 use std::path::Path;
 
 /// Updates a Pearl with the specified field changes.
@@ -17,7 +17,7 @@ use std::path::Path;
 /// * `id` - The Pearl ID (full or partial)
 /// * `title` - Optional new title
 /// * `description` - Optional new description
-/// * `priority` - Optional new priority (0-4)
+/// * `priority` - Optional new priority (0-max_priority)
 /// * `status` - Optional new status
 /// * `add_labels` - Labels to add
 /// * `remove_labels` - Labels to remove
@@ -51,6 +51,9 @@ pub fn execute(
         anyhow::bail!("Pearls repository not initialized. Run 'prl init' first.");
     }
 
+    let config = Config::load(pearls_dir)?;
+    let max_priority = config.max_priority;
+
     // Resolve, update, and save while holding the storage lock.
     let mut storage = Storage::new(pearls_dir.join("issues.jsonl"))?;
     let pearl = storage.with_lock(|storage| {
@@ -73,8 +76,8 @@ pub fn execute(
         }
 
         if let Some(new_priority) = priority {
-            if new_priority > 4 {
-                anyhow::bail!("Priority must be 0-4, got {}", new_priority);
+            if new_priority > max_priority {
+                anyhow::bail!("Priority must be 0-{}, got {}", max_priority, new_priority);
             }
             pearl.priority = new_priority;
         }

--- a/crates/pearls-cli/src/main.rs
+++ b/crates/pearls-cli/src/main.rs
@@ -75,7 +75,7 @@ enum Commands {
         #[arg(long)]
         description_file: Option<String>,
 
-        /// Priority level (0-4, default 2)
+        /// Priority level (0-max_priority, default from config)
         #[arg(long)]
         priority: Option<u8>,
 

--- a/crates/pearls-cli/tests/command_tests.rs
+++ b/crates/pearls-cli/tests/command_tests.rs
@@ -820,6 +820,104 @@ fn test_import_beads_writes_issues() {
 }
 
 #[test]
+fn test_create_rejects_priority_above_configured_max() {
+    let temp_dir = TempDir::new().expect("Failed to create temp directory");
+    let _guard = enter_dir(temp_dir.path());
+    let pearls_dir = init_repo(temp_dir.path());
+
+    let mut config = pearls_core::Config::default();
+    config.default_priority = 1;
+    config.max_priority = 1;
+    config.save(&pearls_dir).expect("Failed to save config");
+
+    let error = pearls_cli::commands::create::execute(
+        "Too High".to_string(),
+        None,
+        None,
+        Some(2),
+        vec![],
+        Some("alice".to_string()),
+    )
+    .expect_err("Create should reject priority above max_priority");
+
+    assert!(
+        error.to_string().contains("Priority must be 0-1, got 2"),
+        "Unexpected error: {error}"
+    );
+}
+
+#[test]
+fn test_update_rejects_priority_above_configured_max() {
+    let temp_dir = TempDir::new().expect("Failed to create temp directory");
+    let _guard = enter_dir(temp_dir.path());
+    let pearls_dir = init_repo(temp_dir.path());
+
+    let mut config = pearls_core::Config::default();
+    config.default_priority = 1;
+    config.max_priority = 1;
+    config.save(&pearls_dir).expect("Failed to save config");
+
+    let pearl = pearls_core::Pearl::new("Update target".to_string(), "alice".to_string());
+    let pearl_id = pearl.id.clone();
+    let mut storage =
+        Storage::new(pearls_dir.join("issues.jsonl")).expect("Failed to create storage");
+    storage.save(&pearl).expect("Failed to save pearl");
+
+    let error = pearls_cli::commands::update::execute(
+        pearl_id,
+        None,
+        None,
+        None,
+        Some(2),
+        None,
+        vec![],
+        vec![],
+    )
+    .expect_err("Update should reject priority above max_priority");
+
+    assert!(
+        error.to_string().contains("Priority must be 0-1, got 2"),
+        "Unexpected error: {error}"
+    );
+}
+
+#[test]
+fn test_import_beads_skips_priorities_above_configured_max() {
+    let temp_dir = TempDir::new().expect("Failed to create temp directory");
+    let _guard = enter_dir(temp_dir.path());
+    let pearls_dir = init_repo(temp_dir.path());
+
+    let mut config = pearls_core::Config::default();
+    config.default_priority = 1;
+    config.max_priority = 1;
+    config.save(&pearls_dir).expect("Failed to save config");
+
+    let mut allowed = pearls_core::Pearl::new("Allowed".to_string(), "alice".to_string());
+    allowed.priority = 1;
+    let mut too_high = pearls_core::Pearl::new("Too High".to_string(), "alice".to_string());
+    too_high.priority = 3;
+
+    let beads_path = temp_dir.path().join("beads.jsonl");
+    let payload = format!(
+        "{}\n{}\n",
+        serde_json::to_string(&allowed).expect("serialize allowed"),
+        serde_json::to_string(&too_high).expect("serialize too_high")
+    );
+    fs::write(&beads_path, payload).expect("Failed to write beads file");
+
+    pearls_cli::commands::import::import_beads(beads_path.to_string_lossy().to_string())
+        .expect("Import failed");
+
+    let storage = Storage::new(pearls_dir.join("issues.jsonl")).expect("Failed to create storage");
+    let pearls = storage.load_all().expect("Failed to load pearls");
+    assert_eq!(pearls.len(), 1, "Only one Pearl should be imported");
+    assert_eq!(
+        pearls[0].id, allowed.id,
+        "Only allowed priority should persist"
+    );
+}
+
+#[test]
 fn test_meta_set_updates_metadata() {
     let temp_dir = TempDir::new().expect("Failed to create temp directory");
     let _guard = enter_dir(temp_dir.path());

--- a/crates/pearls-core/src/config.rs
+++ b/crates/pearls-core/src/config.rs
@@ -22,9 +22,13 @@ pub enum OutputFormat {
 /// Configuration for Pearls behavior.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
-    /// Default priority for new Pearls (0-4).
+    /// Default priority for new Pearls (0-`max_priority`).
     #[serde(default = "default_priority")]
     pub default_priority: u8,
+
+    /// Maximum allowed priority value (0-31).
+    #[serde(default = "default_max_priority")]
+    pub max_priority: u8,
 
     /// Number of days before closed Pearls are archived.
     #[serde(default = "default_compact_threshold")]
@@ -48,6 +52,11 @@ fn default_priority() -> u8 {
     2
 }
 
+/// Default maximum priority value.
+fn default_max_priority() -> u8 {
+    4
+}
+
 /// Default compaction threshold in days.
 fn default_compact_threshold() -> u32 {
     30
@@ -57,6 +66,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             default_priority: default_priority(),
+            max_priority: default_max_priority(),
             compact_threshold_days: default_compact_threshold(),
             use_index: false,
             output_format: OutputFormat::default(),
@@ -111,7 +121,8 @@ impl Config {
     /// Applies environment variable overrides to the configuration.
     ///
     /// Supported environment variables:
-    /// - `PEARLS_DEFAULT_PRIORITY` - Default priority (0-4)
+    /// - `PEARLS_DEFAULT_PRIORITY` - Default priority (0-`max_priority`)
+    /// - `PEARLS_MAX_PRIORITY` - Maximum priority value (0-31)
     /// - `PEARLS_COMPACT_THRESHOLD_DAYS` - Compaction threshold in days
     /// - `PEARLS_USE_INDEX` - Whether to use index file (true/false)
     /// - `PEARLS_OUTPUT_FORMAT` - Output format (json/table/plain)
@@ -127,9 +138,13 @@ impl Config {
     fn apply_env_overrides(&mut self) -> Result<()> {
         if let Ok(val) = std::env::var("PEARLS_DEFAULT_PRIORITY") {
             self.default_priority = val.parse().map_err(|_| {
-                crate::Error::InvalidPearl(
-                    "PEARLS_DEFAULT_PRIORITY must be a number 0-4".to_string(),
-                )
+                crate::Error::InvalidPearl("PEARLS_DEFAULT_PRIORITY must be a number".to_string())
+            })?;
+        }
+
+        if let Ok(val) = std::env::var("PEARLS_MAX_PRIORITY") {
+            self.max_priority = val.parse().map_err(|_| {
+                crate::Error::InvalidPearl("PEARLS_MAX_PRIORITY must be a number 0-31".to_string())
             })?;
         }
 
@@ -180,13 +195,21 @@ impl Config {
     /// # Errors
     ///
     /// Returns an error if:
-    /// - default_priority is out of range (0-4)
+    /// - default_priority is out of range (0-`max_priority`)
+    /// - max_priority is out of range (0-31)
     /// - compact_threshold_days is zero
     fn validate(&self) -> Result<()> {
-        if self.default_priority > 4 {
+        if self.max_priority > 31 {
             return Err(crate::Error::InvalidPearl(format!(
-                "default_priority must be 0-4, got {}",
-                self.default_priority
+                "max_priority must be 0-31, got {}",
+                self.max_priority
+            )));
+        }
+
+        if self.default_priority > self.max_priority {
+            return Err(crate::Error::InvalidPearl(format!(
+                "default_priority must be 0-{}, got {}",
+                self.max_priority, self.default_priority
             )));
         }
 
@@ -234,6 +257,7 @@ mod tests {
 
     fn clear_all_env_vars() {
         std::env::remove_var("PEARLS_DEFAULT_PRIORITY");
+        std::env::remove_var("PEARLS_MAX_PRIORITY");
         std::env::remove_var("PEARLS_COMPACT_THRESHOLD_DAYS");
         std::env::remove_var("PEARLS_USE_INDEX");
         std::env::remove_var("PEARLS_OUTPUT_FORMAT");
@@ -252,6 +276,7 @@ mod tests {
         run_env_test(|| {
             let config = Config::default();
             assert_eq!(config.default_priority, 2);
+            assert_eq!(config.max_priority, 4);
             assert_eq!(config.compact_threshold_days, 30);
             assert!(!config.use_index);
             assert_eq!(config.output_format, OutputFormat::Table);
@@ -276,6 +301,7 @@ mod tests {
             let config_path = temp_dir.path().join("config.toml");
             let content = r#"
 default_priority = 1
+max_priority = 7
 compact_threshold_days = 60
 use_index = true
 output_format = "json"
@@ -285,6 +311,7 @@ auto_close_on_commit = true
 
             let config = Config::load(temp_dir.path()).unwrap();
             assert_eq!(config.default_priority, 1);
+            assert_eq!(config.max_priority, 7);
             assert_eq!(config.compact_threshold_days, 60);
             assert!(config.use_index);
             assert_eq!(config.output_format, OutputFormat::Json);
@@ -298,6 +325,32 @@ auto_close_on_commit = true
             let temp_dir = TempDir::new().unwrap();
             let config_path = temp_dir.path().join("config.toml");
             let content = "default_priority = 5";
+            std::fs::write(&config_path, content).unwrap();
+
+            let result = Config::load(temp_dir.path());
+            assert!(result.is_err());
+        });
+    }
+
+    #[test]
+    fn test_config_validation_invalid_max_priority() {
+        run_env_test(|| {
+            let temp_dir = TempDir::new().unwrap();
+            let config_path = temp_dir.path().join("config.toml");
+            let content = "max_priority = 32";
+            std::fs::write(&config_path, content).unwrap();
+
+            let result = Config::load(temp_dir.path());
+            assert!(result.is_err());
+        });
+    }
+
+    #[test]
+    fn test_config_validation_default_priority_exceeds_max() {
+        run_env_test(|| {
+            let temp_dir = TempDir::new().unwrap();
+            let config_path = temp_dir.path().join("config.toml");
+            let content = "default_priority = 5\nmax_priority = 4";
             std::fs::write(&config_path, content).unwrap();
 
             let result = Config::load(temp_dir.path());
@@ -337,6 +390,17 @@ auto_close_on_commit = true
             std::env::set_var("PEARLS_COMPACT_THRESHOLD_DAYS", "90");
             let config = Config::load(temp_dir.path()).unwrap();
             assert_eq!(config.compact_threshold_days, 90);
+        });
+    }
+
+    #[test]
+    fn test_config_env_override_max_priority() {
+        run_env_test(|| {
+            let temp_dir = TempDir::new().unwrap();
+
+            std::env::set_var("PEARLS_MAX_PRIORITY", "31");
+            let config = Config::load(temp_dir.path()).unwrap();
+            assert_eq!(config.max_priority, 31);
         });
     }
 
@@ -385,6 +449,17 @@ auto_close_on_commit = true
     }
 
     #[test]
+    fn test_config_env_invalid_max_priority() {
+        run_env_test(|| {
+            let temp_dir = TempDir::new().unwrap();
+
+            std::env::set_var("PEARLS_MAX_PRIORITY", "invalid");
+            let result = Config::load(temp_dir.path());
+            assert!(result.is_err());
+        });
+    }
+
+    #[test]
     fn test_config_env_invalid_format() {
         run_env_test(|| {
             let temp_dir = TempDir::new().unwrap();
@@ -402,6 +477,7 @@ auto_close_on_commit = true
 
             let original = Config {
                 default_priority: 1,
+                max_priority: 7,
                 compact_threshold_days: 45,
                 use_index: true,
                 output_format: OutputFormat::Json,
@@ -412,6 +488,7 @@ auto_close_on_commit = true
             let loaded = Config::load(temp_dir.path()).unwrap();
 
             assert_eq!(original.default_priority, loaded.default_priority);
+            assert_eq!(original.max_priority, loaded.max_priority);
             assert_eq!(
                 original.compact_threshold_days,
                 loaded.compact_threshold_days

--- a/crates/pearls-core/src/models.rs
+++ b/crates/pearls-core/src/models.rs
@@ -70,7 +70,7 @@ pub struct Pearl {
     pub description: String,
     /// Current status in the FSM.
     pub status: Status,
-    /// Priority level (0=critical, 4=trivial).
+    /// Priority level (0=highest, default 2). Range is configurable via `max_priority` (up to 31).
     #[serde(default = "default_priority")]
     pub priority: u8,
     /// Unix timestamp of creation.
@@ -145,7 +145,7 @@ impl Pearl {
     ///
     /// Returns an error if:
     /// - Title is empty
-    /// - Priority is out of range (0-4)
+    /// - Priority is out of range (0-31)
     /// - ID format is invalid
     pub fn validate(&self) -> crate::Result<()> {
         if self.title.is_empty() {
@@ -154,9 +154,9 @@ impl Pearl {
             ));
         }
 
-        if self.priority > 4 {
+        if self.priority > 31 {
             return Err(crate::Error::InvalidPearl(format!(
-                "Priority must be 0-4, got {}",
+                "Priority must be 0-31, got {}",
                 self.priority
             )));
         }

--- a/crates/pearls-core/tests/models_props.rs
+++ b/crates/pearls-core/tests/models_props.rs
@@ -48,7 +48,7 @@ fn arb_pearl() -> impl Strategy<Value = Pearl> {
         prop::string::string_regex("[a-zA-Z0-9 ]{1,100}").unwrap(),
         any::<String>(),
         arb_status(),
-        0u8..=4u8,
+        0u8..=31u8,
         1i64..1_000_000_000_000i64,
         1i64..1_000_000_000_000i64,
         prop::string::string_regex("[a-zA-Z0-9_-]{1,50}").unwrap(),
@@ -139,11 +139,11 @@ proptest! {
     /// **Validates: Requirements 2.4, 2.5, 2.6, 2.7, 2.8**
     ///
     /// For any Pearl, all fields must conform to their type constraints:
-    /// priority in range 0-4, status in valid enum, timestamps as positive integers,
+    /// priority in range 0-31, status in valid enum, timestamps as positive integers,
     /// labels as string array, dependencies as Dependency array.
     #[test]
     fn test_schema_conformance(pearl in arb_pearl()) {
-        prop_assert!(pearl.priority <= 4, "Priority must be 0-4, got {}", pearl.priority);
+        prop_assert!(pearl.priority <= 31, "Priority must be 0-31, got {}", pearl.priority);
         prop_assert!(pearl.created_at > 0, "created_at must be positive");
         prop_assert!(pearl.updated_at > 0, "updated_at must be positive");
 

--- a/crates/pearls-mcp/src/server.rs
+++ b/crates/pearls-mcp/src/server.rs
@@ -250,10 +250,10 @@ impl PearlsMcp {
             }
 
             if let Some(priority) = item.priority {
-                if priority > 4 {
+                if priority > config.max_priority {
                     return Err(AppError::InvalidInput(format!(
-                        "Priority must be 0-4, got {}",
-                        priority
+                        "Priority must be 0-{}, got {}",
+                        config.max_priority, priority
                     )));
                 }
                 pearl.priority = priority;
@@ -295,6 +295,7 @@ impl PearlsMcp {
         }
 
         let repo = self.repo_context()?;
+        let config = repo.load_config()?;
         let mut storage = repo.open_storage()?;
         let mut pearls = storage.load_all()?;
         let full_id = resolve_pearl_id(&input.id, &pearls)?;
@@ -312,10 +313,10 @@ impl PearlsMcp {
             pearl.description = description;
         }
         if let Some(priority) = input.priority {
-            if priority > 4 {
+            if priority > config.max_priority {
                 return Err(AppError::InvalidInput(format!(
-                    "Priority must be 0-4, got {}",
-                    priority
+                    "Priority must be 0-{}, got {}",
+                    config.max_priority, priority
                 )));
             }
             pearl.priority = priority;
@@ -1274,6 +1275,66 @@ mod tests {
             .ready_tool(ReadyInput { limit: None })
             .expect("ready failed");
         assert!(ready.ready.is_empty());
+    }
+
+    #[test]
+    fn test_priority_respects_configured_max_for_create_and_update() {
+        let temp = init_repo();
+        let pearls_dir = temp.path().join(".pearls");
+        let mut config = Config::default();
+        config.default_priority = 1;
+        config.max_priority = 1;
+        config.save(&pearls_dir).expect("Failed to save config");
+
+        let server = server_for(&temp);
+
+        let create_error = server
+            .create_tool(CreateInput {
+                items: vec![CreateItem {
+                    title: "Too High".to_string(),
+                    description: None,
+                    priority: Some(2),
+                    labels: None,
+                    author: None,
+                }],
+            })
+            .expect_err("create should reject priority above max_priority");
+        assert!(
+            create_error
+                .to_string()
+                .contains("Priority must be 0-1, got 2"),
+            "Unexpected create error: {create_error}"
+        );
+
+        let created = server
+            .create_tool(CreateInput {
+                items: vec![CreateItem {
+                    title: "Allowed".to_string(),
+                    description: None,
+                    priority: Some(1),
+                    labels: None,
+                    author: None,
+                }],
+            })
+            .expect("create allowed priority failed");
+
+        let update_error = server
+            .update_tool(UpdateInput {
+                id: created.pearls[0].id.clone(),
+                title: None,
+                description: None,
+                priority: Some(2),
+                status: None,
+                add_labels: None,
+                remove_labels: None,
+            })
+            .expect_err("update should reject priority above max_priority");
+        assert!(
+            update_error
+                .to_string()
+                .contains("Priority must be 0-1, got 2"),
+            "Unexpected update error: {update_error}"
+        );
     }
 
     #[test]

--- a/crates/pearls-mcp/src/types.rs
+++ b/crates/pearls-mcp/src/types.rs
@@ -53,7 +53,7 @@ pub struct CreateItem {
     pub title: String,
     /// Description of the Pearl.
     pub description: Option<String>,
-    /// Priority level (0-4).
+    /// Priority level (0-max_priority, up to 31).
     pub priority: Option<u8>,
     /// Labels to assign.
     pub labels: Option<Vec<String>>,
@@ -100,7 +100,7 @@ pub struct UpdateInput {
     pub title: Option<String>,
     /// New description.
     pub description: Option<String>,
-    /// New priority (0-4).
+    /// New priority (0-max_priority, up to 31).
     pub priority: Option<u8>,
     /// New status.
     pub status: Option<String>,

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -166,7 +166,7 @@ When in doubt, call `show` on the `from` Pearl and verify the `deps` list includ
 Pearls are issues with:
 - A stable ID (`prl-xxxxxx`)
 - A status (Open, InProgress, Blocked, Deferred, Closed)
-- Priority (`P0` to `P4`)
+- Priority (numeric, default range `0` to `4`)
 - Labels, dependencies, metadata
 - Author and timestamps
 
@@ -490,7 +490,8 @@ prl show prl-abc123 --absolute-time
 The config file lives at `.pearls/config.toml`.
 
 Key options:
-- `default_priority` (0-4)
+- `default_priority` (0-`max_priority`)
+- `max_priority` (0-31, default `4`)
 - `compact_threshold_days`
 - `use_index`
 - `output_format` (`json`, `table`, `plain`)
@@ -498,6 +499,7 @@ Key options:
 
 Environment overrides:
 - `PEARLS_DEFAULT_PRIORITY`
+- `PEARLS_MAX_PRIORITY`
 - `PEARLS_COMPACT_THRESHOLD_DAYS`
 - `PEARLS_USE_INDEX`
 - `PEARLS_OUTPUT_FORMAT`

--- a/skills/pearls-cli/SKILL.md
+++ b/skills/pearls-cli/SKILL.md
@@ -66,5 +66,5 @@ prl status --detailed
 
 ## Files and config
 - Data lives in `.pearls/issues.jsonl`; archived items in `.pearls/archive.jsonl`.
-- Config lives at `.pearls/config.toml`; environment overrides include `PEARLS_DEFAULT_PRIORITY` and related keys.
+- Config lives at `.pearls/config.toml`; environment overrides include `PEARLS_DEFAULT_PRIORITY`, `PEARLS_MAX_PRIORITY`, and related keys.
 - Use `prl list --format json` for machine-readable output.

--- a/skills/pearls-cli/references/user-guide.md
+++ b/skills/pearls-cli/references/user-guide.md
@@ -166,7 +166,7 @@ When in doubt, call `show` on the `from` Pearl and verify the `deps` list includ
 Pearls are issues with:
 - A stable ID (`prl-xxxxxx`)
 - A status (Open, InProgress, Blocked, Deferred, Closed)
-- Priority (`P0` to `P4`)
+- Priority (numeric, default range `0` to `4`)
 - Labels, dependencies, metadata
 - Author and timestamps
 
@@ -490,7 +490,8 @@ prl show prl-abc123 --absolute-time
 The config file lives at `.pearls/config.toml`.
 
 Key options:
-- `default_priority` (0-4)
+- `default_priority` (0-`max_priority`)
+- `max_priority` (0-31, default `4`)
 - `compact_threshold_days`
 - `use_index`
 - `output_format` (`json`, `table`, `plain`)
@@ -498,6 +499,7 @@ Key options:
 
 Environment overrides:
 - `PEARLS_DEFAULT_PRIORITY`
+- `PEARLS_MAX_PRIORITY`
 - `PEARLS_COMPACT_THRESHOLD_DAYS`
 - `PEARLS_USE_INDEX`
 - `PEARLS_OUTPUT_FORMAT`


### PR DESCRIPTION
## Summary
- add `max_priority` to config with validation (`<=31` and `default_priority <= max_priority`) and env override support
- enforce configured max priority in CLI create/update/import and MCP create/update paths, with clear validation errors
- update docs/tests for configurable priority behavior, including new CLI update regression coverage

## Validation
- cargo test -p pearls-core -p pearls-cli -p pearls-mcp