### PR TITLE
Fix create-time ID collisions and harden storage writes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ rayon = "1.8"
 
 # File locking
 fs2 = "0.4"
+libc = "0.2"
 
 # Time
 chrono = "0.4"

--- a/crates/pearls-cli/src/commands/compact.rs
+++ b/crates/pearls-cli/src/commands/compact.rs
@@ -45,7 +45,9 @@ pub fn execute(threshold_days: Option<u32>, dry_run: bool) -> Result<()> {
     let lock_storage = Storage::new(issues_path.clone())?;
     lock_storage.with_repository_lock(|| {
         let mut storage = Storage::new(issues_path)?;
-        compact_with_storage(&mut storage, pearls_dir, threshold_days, cutoff_ts, dry_run)
+        storage.with_lock(|storage| {
+            compact_with_storage(storage, pearls_dir, threshold_days, cutoff_ts, dry_run)
+        })
     })
 }
 
@@ -56,7 +58,7 @@ fn compact_with_storage(
     cutoff_ts: i64,
     dry_run: bool,
 ) -> Result<()> {
-    let pearls = storage.load_all()?;
+    let pearls = storage.load_all_strict()?;
 
     let (archive_candidates, remaining): (Vec<Pearl>, Vec<Pearl>) = pearls
         .into_iter()
@@ -117,20 +119,38 @@ fn compact_with_storage(
     let archive_path = pearls_dir.join("archive.jsonl");
     let mut archive_storage = Storage::new(archive_path.clone())?;
     let archive_pearls = if archive_path.exists() {
-        archive_storage.load_all()?
+        archive_storage.load_all_strict()?
     } else {
         Vec::new()
     };
 
-    let mut archive_map: HashMap<String, Pearl> = archive_pearls
-        .into_iter()
-        .map(|pearl| (pearl.id.clone(), pearl))
-        .collect();
+    let mut archive_map: HashMap<String, Pearl> = HashMap::new();
+    for pearl in archive_pearls {
+        if let Some(existing) = archive_map.get(&pearl.id) {
+            if existing != &pearl {
+                anyhow::bail!(
+                    "Cannot compact: archive already contains a different Pearl with ID {}",
+                    pearl.id
+                );
+            }
+        } else {
+            archive_map.insert(pearl.id.clone(), pearl);
+        }
+    }
 
     let total = archive_candidates.len();
     let progress = ProgressReporter::new("Archiving", Some(total), 1000);
     for (idx, pearl) in archive_candidates.into_iter().enumerate() {
-        archive_map.entry(pearl.id.clone()).or_insert(pearl);
+        if let Some(existing) = archive_map.get(&pearl.id) {
+            if existing != &pearl {
+                anyhow::bail!(
+                    "Cannot compact Pearl {}: archive already contains a different Pearl with the same ID",
+                    pearl.id
+                );
+            }
+        } else {
+            archive_map.insert(pearl.id.clone(), pearl);
+        }
         progress.report(idx + 1);
     }
     progress.finish(total);

--- a/crates/pearls-cli/src/commands/compact.rs
+++ b/crates/pearls-cli/src/commands/compact.rs
@@ -41,7 +41,21 @@ pub fn execute(threshold_days: Option<u32>, dry_run: bool) -> Result<()> {
     let cutoff = Utc::now() - Duration::days(i64::from(threshold_days));
     let cutoff_ts = cutoff.timestamp();
 
-    let mut storage = Storage::new(pearls_dir.join("issues.jsonl"))?;
+    let issues_path = pearls_dir.join("issues.jsonl");
+    let lock_storage = Storage::new(issues_path.clone())?;
+    lock_storage.with_repository_lock(|| {
+        let mut storage = Storage::new(issues_path)?;
+        compact_with_storage(&mut storage, pearls_dir, threshold_days, cutoff_ts, dry_run)
+    })
+}
+
+fn compact_with_storage(
+    storage: &mut Storage,
+    pearls_dir: &Path,
+    threshold_days: u32,
+    cutoff_ts: i64,
+    dry_run: bool,
+) -> Result<()> {
     let pearls = storage.load_all()?;
 
     let (archive_candidates, remaining): (Vec<Pearl>, Vec<Pearl>) = pearls

--- a/crates/pearls-cli/src/commands/create.rs
+++ b/crates/pearls-cli/src/commands/create.rs
@@ -88,7 +88,11 @@ pub fn execute(
     if !labels.is_empty() {
         super::utils::suggest_labels(&storage, &labels)?;
     }
-    storage.save(&pearl)?;
+    storage.create_new(
+        &mut pearl,
+        Some(&pearls_dir.join("archive.jsonl")),
+        1_000_000,
+    )?;
 
     if is_json_output() {
         println!(
@@ -159,4 +163,3 @@ fn enforce_description_limit(description: &str) -> Result<()> {
     }
     Ok(())
 }
-

--- a/crates/pearls-cli/src/commands/create.rs
+++ b/crates/pearls-cli/src/commands/create.rs
@@ -10,6 +10,8 @@ use anyhow::Result;
 use pearls_core::{Config, Pearl, Storage};
 use std::path::Path;
 
+const MAX_CREATE_ID_ATTEMPTS: u32 = 65_536;
+
 /// Creates a new Pearl with the specified parameters.
 ///
 /// # Arguments
@@ -91,7 +93,7 @@ pub fn execute(
     storage.create_new(
         &mut pearl,
         Some(&pearls_dir.join("archive.jsonl")),
-        1_000_000,
+        MAX_CREATE_ID_ATTEMPTS,
     )?;
 
     if is_json_output() {

--- a/crates/pearls-cli/src/commands/update.rs
+++ b/crates/pearls-cli/src/commands/update.rs
@@ -164,4 +164,3 @@ fn enforce_description_limit(description: &str) -> Result<()> {
     }
     Ok(())
 }
-

--- a/crates/pearls-cli/tests/command_tests.rs
+++ b/crates/pearls-cli/tests/command_tests.rs
@@ -825,9 +825,11 @@ fn test_create_rejects_priority_above_configured_max() {
     let _guard = enter_dir(temp_dir.path());
     let pearls_dir = init_repo(temp_dir.path());
 
-    let mut config = pearls_core::Config::default();
-    config.default_priority = 1;
-    config.max_priority = 1;
+    let config = pearls_core::Config {
+        default_priority: 1,
+        max_priority: 1,
+        ..Default::default()
+    };
     config.save(&pearls_dir).expect("Failed to save config");
 
     let error = pearls_cli::commands::create::execute(
@@ -852,9 +854,11 @@ fn test_update_rejects_priority_above_configured_max() {
     let _guard = enter_dir(temp_dir.path());
     let pearls_dir = init_repo(temp_dir.path());
 
-    let mut config = pearls_core::Config::default();
-    config.default_priority = 1;
-    config.max_priority = 1;
+    let config = pearls_core::Config {
+        default_priority: 1,
+        max_priority: 1,
+        ..Default::default()
+    };
     config.save(&pearls_dir).expect("Failed to save config");
 
     let pearl = pearls_core::Pearl::new("Update target".to_string(), "alice".to_string());
@@ -887,9 +891,11 @@ fn test_import_beads_skips_priorities_above_configured_max() {
     let _guard = enter_dir(temp_dir.path());
     let pearls_dir = init_repo(temp_dir.path());
 
-    let mut config = pearls_core::Config::default();
-    config.default_priority = 1;
-    config.max_priority = 1;
+    let config = pearls_core::Config {
+        default_priority: 1,
+        max_priority: 1,
+        ..Default::default()
+    };
     config.save(&pearls_dir).expect("Failed to save config");
 
     let mut allowed = pearls_core::Pearl::new("Allowed".to_string(), "alice".to_string());

--- a/crates/pearls-cli/tests/command_tests.rs
+++ b/crates/pearls-cli/tests/command_tests.rs
@@ -741,6 +741,121 @@ fn test_compact_archives_closed_pearls() {
 }
 
 #[test]
+fn test_compact_rejects_different_archived_pearl_with_same_id() {
+    let temp_dir = TempDir::new().expect("Failed to create temp directory");
+    let _guard = enter_dir(temp_dir.path());
+    let pearls_dir = init_repo(temp_dir.path());
+
+    let mut active = pearls_core::Pearl::new("Active duplicate".to_string(), "alice".to_string());
+    active.status = pearls_core::Status::Closed;
+    active.updated_at = (chrono::Utc::now() - chrono::Duration::days(30)).timestamp();
+
+    let mut archived = active.clone();
+    archived.title = "Different archived duplicate".to_string();
+
+    let mut storage =
+        Storage::new(pearls_dir.join("issues.jsonl")).expect("Failed to create storage");
+    storage.save(&active).expect("Failed to save active pearl");
+
+    let mut archive_storage =
+        Storage::new(pearls_dir.join("archive.jsonl")).expect("Failed to create archive storage");
+    archive_storage
+        .save(&archived)
+        .expect("Failed to save archived pearl");
+
+    let err = pearls_cli::commands::compact::execute(Some(7), false)
+        .expect_err("Compact should reject divergent duplicate archived IDs");
+    assert!(
+        err.to_string().contains("same ID"),
+        "unexpected error: {err}"
+    );
+
+    let active_after = storage.load_all().expect("Failed to reload active pearls");
+    assert_eq!(active_after.len(), 1, "active Pearl must not be dropped");
+    assert_eq!(active_after[0].title, active.title);
+}
+
+#[test]
+fn test_compact_allows_identical_archived_pearl_with_same_id() {
+    let temp_dir = TempDir::new().expect("Failed to create temp directory");
+    let _guard = enter_dir(temp_dir.path());
+    let pearls_dir = init_repo(temp_dir.path());
+
+    let mut active = pearls_core::Pearl::new("Already Archived".to_string(), "alice".to_string());
+    active.status = pearls_core::Status::Closed;
+    active.updated_at = (chrono::Utc::now() - chrono::Duration::days(30)).timestamp();
+
+    let mut storage =
+        Storage::new(pearls_dir.join("issues.jsonl")).expect("Failed to create storage");
+    storage.save(&active).expect("Failed to save active pearl");
+
+    let mut archive_storage =
+        Storage::new(pearls_dir.join("archive.jsonl")).expect("Failed to create archive storage");
+    archive_storage
+        .save(&active)
+        .expect("Failed to save archived pearl");
+
+    pearls_cli::commands::compact::execute(Some(7), false)
+        .expect("Compact should allow identical archived duplicate");
+
+    let active_after = storage.load_all().expect("Failed to reload active pearls");
+    assert!(active_after.is_empty(), "active Pearl should be archived");
+    let archived_after = archive_storage
+        .load_all()
+        .expect("Failed to reload archived pearls");
+    assert_eq!(archived_after.len(), 1);
+    assert_eq!(archived_after[0], active);
+}
+
+#[test]
+fn test_compact_fails_closed_on_malformed_active_jsonl() {
+    let temp_dir = TempDir::new().expect("Failed to create temp directory");
+    let _guard = enter_dir(temp_dir.path());
+    let pearls_dir = init_repo(temp_dir.path());
+    let malformed = "{not valid json}\n";
+    fs::write(pearls_dir.join("issues.jsonl"), malformed).expect("Failed to write issues");
+
+    let err = pearls_cli::commands::compact::execute(Some(7), false)
+        .expect_err("Compact should fail closed on malformed active JSONL");
+    assert!(err.to_string().contains("Invalid Pearl JSON"));
+
+    let active_after = fs::read_to_string(pearls_dir.join("issues.jsonl"))
+        .expect("Failed to read active after compact");
+    assert_eq!(active_after, malformed);
+}
+
+#[test]
+fn test_compact_fails_closed_on_malformed_archive_jsonl() {
+    let temp_dir = TempDir::new().expect("Failed to create temp directory");
+    let _guard = enter_dir(temp_dir.path());
+    let pearls_dir = init_repo(temp_dir.path());
+
+    let mut active = pearls_core::Pearl::new("Old Closed".to_string(), "alice".to_string());
+    active.status = pearls_core::Status::Closed;
+    active.updated_at = (chrono::Utc::now() - chrono::Duration::days(30)).timestamp();
+
+    let mut storage =
+        Storage::new(pearls_dir.join("issues.jsonl")).expect("Failed to create storage");
+    storage.save(&active).expect("Failed to save active pearl");
+    let before_active = fs::read_to_string(pearls_dir.join("issues.jsonl"))
+        .expect("Failed to read active before compact");
+
+    let malformed = "{not valid json}\n";
+    fs::write(pearls_dir.join("archive.jsonl"), malformed).expect("Failed to write archive");
+
+    let err = pearls_cli::commands::compact::execute(Some(7), false)
+        .expect_err("Compact should fail closed on malformed archive JSONL");
+    assert!(err.to_string().contains("Invalid Pearl JSON"));
+
+    let active_after = fs::read_to_string(pearls_dir.join("issues.jsonl"))
+        .expect("Failed to read active after compact");
+    let archive_after = fs::read_to_string(pearls_dir.join("archive.jsonl"))
+        .expect("Failed to read archive after compact");
+    assert_eq!(active_after, before_active);
+    assert_eq!(archive_after, malformed);
+}
+
+#[test]
 fn test_compact_dry_run_keeps_files() {
     let temp_dir = TempDir::new().expect("Failed to create temp directory");
     let _guard = enter_dir(temp_dir.path());

--- a/crates/pearls-cli/tests/integration_flow_tests.rs
+++ b/crates/pearls-cli/tests/integration_flow_tests.rs
@@ -5,6 +5,7 @@
 use git2::Repository;
 use pearls_cli::OutputFormatter;
 use pearls_core::{Pearl, Status, Storage};
+use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -294,4 +295,60 @@ fn test_concurrent_cli_writes_are_serialized_without_data_loss() {
         let parsed: Result<serde_json::Value, _> = serde_json::from_str(line);
         assert!(parsed.is_ok(), "Each JSONL line must be valid JSON");
     }
+}
+
+#[test]
+fn test_concurrent_cli_create_same_title_author_persists_unique_pearls() {
+    let temp_dir = TempDir::new().expect("Failed to create temp directory");
+    Repository::init(temp_dir.path()).expect("Failed to init git repo");
+    let prl_bin = env!("CARGO_BIN_EXE_prl");
+
+    let init = Command::new(prl_bin)
+        .arg("init")
+        .current_dir(temp_dir.path())
+        .output()
+        .expect("Failed to run prl init");
+    assert!(
+        init.status.success(),
+        "prl init failed: {}",
+        String::from_utf8_lossy(&init.stderr)
+    );
+
+    let total_creates = 30;
+    let mut handles = Vec::with_capacity(total_creates);
+    for _ in 0..total_creates {
+        let repo = temp_dir.path().to_path_buf();
+        let bin = prl_bin.to_string();
+        handles.push(std::thread::spawn(move || {
+            Command::new(bin)
+                .arg("create")
+                .arg("Same concurrent title")
+                .arg("--author")
+                .arg("same-author")
+                .arg("--json")
+                .current_dir(repo)
+                .output()
+                .expect("Failed to run prl create")
+        }));
+    }
+
+    let mut failures = Vec::new();
+    for handle in handles {
+        let output = handle.join().expect("create thread panicked");
+        if !output.status.success() {
+            failures.push(String::from_utf8_lossy(&output.stderr).to_string());
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "Concurrent creates failed: {}",
+        failures.join(" | ")
+    );
+
+    let storage = Storage::new(temp_dir.path().join(".pearls/issues.jsonl"))
+        .expect("Failed to create storage");
+    let pearls = storage.load_all_strict().expect("Failed to load pearls");
+    assert_eq!(pearls.len(), total_creates);
+    let ids: HashSet<&str> = pearls.iter().map(|pearl| pearl.id.as_str()).collect();
+    assert_eq!(ids.len(), total_creates, "created IDs must be unique");
 }

--- a/crates/pearls-core/Cargo.toml
+++ b/crates/pearls-core/Cargo.toml
@@ -16,6 +16,7 @@ thiserror = { workspace = true }
 anyhow = { workspace = true }
 rayon = { workspace = true }
 fs2 = { workspace = true }
+libc = { workspace = true }
 chrono = { workspace = true }
 
 [dev-dependencies]

--- a/crates/pearls-core/src/storage.rs
+++ b/crates/pearls-core/src/storage.rs
@@ -15,6 +15,10 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 const INDEX_MAGIC: [u8; 8] = *b"PRLIDX1\0";
 const INDEX_VERSION: u8 = 1;
+const MAX_INDEX_FILE_BYTES: u64 = 128 * 1024 * 1024;
+const MAX_INDEX_ENTRIES: u64 = 1_000_000;
+const MAX_INDEX_ID_BYTES: usize = 256;
+const MAX_JSONL_LINE_BYTES: usize = 16 * 1024 * 1024;
 static TEMP_FILE_COUNTER: AtomicU64 = AtomicU64::new(0);
 thread_local! {
     static REENTRANT_LOCK_DEPTHS: RefCell<HashMap<PathBuf, usize>> = RefCell::new(HashMap::new());
@@ -29,14 +33,24 @@ fn invalid_index_error(message: &str) -> Error {
 
 fn read_u32<R: std::io::Read>(reader: &mut R) -> Result<u32> {
     let mut buf = [0u8; 4];
-    reader.read_exact(&mut buf)?;
+    read_index_exact(reader, &mut buf)?;
     Ok(u32::from_le_bytes(buf))
 }
 
 fn read_u64<R: std::io::Read>(reader: &mut R) -> Result<u64> {
     let mut buf = [0u8; 8];
-    reader.read_exact(&mut buf)?;
+    read_index_exact(reader, &mut buf)?;
     Ok(u64::from_le_bytes(buf))
+}
+
+fn read_index_exact<R: std::io::Read>(reader: &mut R, buf: &mut [u8]) -> Result<()> {
+    reader.read_exact(buf).map_err(|err| {
+        if err.kind() == std::io::ErrorKind::UnexpectedEof {
+            invalid_index_error("Truncated index file")
+        } else {
+            Error::Io(err)
+        }
+    })
 }
 
 fn write_u32<W: std::io::Write>(writer: &mut W, value: u32) -> Result<()> {
@@ -47,6 +61,154 @@ fn write_u32<W: std::io::Write>(writer: &mut W, value: u32) -> Result<()> {
 fn write_u64<W: std::io::Write>(writer: &mut W, value: u64) -> Result<()> {
     writer.write_all(&value.to_le_bytes())?;
     Ok(())
+}
+
+fn read_bounded_jsonl_line<R: std::io::BufRead>(
+    reader: &mut R,
+    path: &Path,
+    line_idx: usize,
+    buffer: &mut Vec<u8>,
+) -> Result<usize> {
+    buffer.clear();
+
+    loop {
+        let available = reader.fill_buf()?;
+        if available.is_empty() {
+            return Ok(buffer.len());
+        }
+
+        let take = available
+            .iter()
+            .position(|byte| *byte == b'\n')
+            .map_or(available.len(), |pos| pos + 1);
+
+        if buffer.len().saturating_add(take) > MAX_JSONL_LINE_BYTES {
+            return Err(Error::Io(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "Pearl JSON line in {} at line {} exceeds {} bytes",
+                    path.display(),
+                    line_idx,
+                    MAX_JSONL_LINE_BYTES
+                ),
+            )));
+        }
+
+        let saw_newline = available[..take].last() == Some(&b'\n');
+        buffer.extend_from_slice(&available[..take]);
+        reader.consume(take);
+
+        if saw_newline {
+            return Ok(buffer.len());
+        }
+    }
+}
+
+fn normalize_lock_path(path: PathBuf) -> PathBuf {
+    let Some(parent) = path.parent() else {
+        return path;
+    };
+    let Some(file_name) = path.file_name() else {
+        return path;
+    };
+
+    parent
+        .canonicalize()
+        .map(|canonical_parent| canonical_parent.join(file_name))
+        .unwrap_or(path)
+}
+
+fn normalize_managed_path(path: &Path, label: &str) -> Result<PathBuf> {
+    reject_managed_path_symlinks(path, label)?;
+
+    let Some(parent) = path.parent() else {
+        return Ok(path.to_path_buf());
+    };
+    let Some(file_name) = path.file_name() else {
+        return Ok(path.to_path_buf());
+    };
+
+    match parent.canonicalize() {
+        Ok(parent) => Ok(parent.join(file_name)),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(path.to_path_buf()),
+        Err(err) => Err(Error::Io(err)),
+    }
+}
+
+fn unique_temp_path(path: &Path, marker: &str) -> PathBuf {
+    let counter = TEMP_FILE_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0_u128, |duration| duration.as_nanos());
+    let temp_extension = format!("{marker}.tmp.{}.{}.{}", std::process::id(), nanos, counter);
+    path.with_extension(temp_extension)
+}
+
+#[cfg(unix)]
+fn open_existing_no_follow(path: &Path) -> Result<std::fs::File> {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(path)
+        .map_err(Error::Io)
+}
+
+#[cfg(unix)]
+fn open_lock_no_follow(path: &Path) -> Result<std::fs::File> {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(path)
+        .map_err(Error::Io)
+}
+
+#[cfg(not(unix))]
+fn open_lock_no_follow(path: &Path) -> Result<std::fs::File> {
+    OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(path)
+        .map_err(Error::Io)
+}
+
+#[cfg(not(unix))]
+fn open_existing_no_follow(path: &Path) -> Result<std::fs::File> {
+    std::fs::File::open(path).map_err(Error::Io)
+}
+
+fn reject_managed_path_symlinks(path: &Path, label: &str) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        match std::fs::symlink_metadata(parent) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                return Err(Error::Io(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    format!("{label} parent cannot be a symlink: {}", parent.display()),
+                )));
+            }
+            Ok(_) => {}
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(err) => return Err(Error::Io(err)),
+        }
+    }
+
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => Err(Error::Io(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("{label} cannot be a symlink: {}", path.display()),
+        ))),
+        Ok(_) => Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(Error::Io(err)),
+    }
 }
 
 /// Optional index for fast Pearl lookups by ID.
@@ -71,10 +233,15 @@ impl Index {
     ///
     /// A new Index instance.
     pub fn new(path: PathBuf) -> Self {
+        let path = normalize_managed_path(&path, "Index file path").unwrap_or(path);
         Self {
             map: HashMap::new(),
             path,
         }
+    }
+
+    fn validate_path(path: &Path) -> Result<()> {
+        reject_managed_path_symlinks(path, "Index file path")
     }
 
     /// Loads an Index from disk, or returns an empty Index if the file does not exist.
@@ -91,37 +258,62 @@ impl Index {
     ///
     /// Returns an error if the file exists but is invalid or unreadable.
     pub fn load(path: PathBuf) -> Result<Self> {
-        use std::fs::File;
-        use std::io::Read;
+        Self::validate_path(&path)?;
+        let path = normalize_managed_path(&path, "Index file path")?;
 
         if !path.exists() {
             return Ok(Self::new(path));
         }
 
-        let mut file = File::open(&path)?;
+        let file_len = std::fs::metadata(&path)?.len();
+        if file_len > MAX_INDEX_FILE_BYTES {
+            return Err(invalid_index_error(
+                "Index file exceeds maximum supported size",
+            ));
+        }
+
+        let mut file = open_existing_no_follow(&path)?;
 
         let mut magic = [0u8; 8];
-        file.read_exact(&mut magic)?;
+        read_index_exact(&mut file, &mut magic)?;
         if magic != INDEX_MAGIC {
             return Err(invalid_index_error("Invalid index magic header"));
         }
 
         let mut version = [0u8; 1];
-        file.read_exact(&mut version)?;
+        read_index_exact(&mut file, &mut version)?;
         if version[0] != INDEX_VERSION {
             return Err(invalid_index_error("Unsupported index version"));
         }
 
         let count = read_u64(&mut file)?;
-        let mut map = HashMap::with_capacity(count as usize);
+        if count > MAX_INDEX_ENTRIES {
+            return Err(invalid_index_error(
+                "Index entry count exceeds maximum supported size",
+            ));
+        }
+        if count.saturating_mul(13) > file_len {
+            return Err(invalid_index_error(
+                "Index entry count exceeds file size bounds",
+            ));
+        }
+
+        let mut map = HashMap::new();
+        map.try_reserve(count as usize)
+            .map_err(|_| invalid_index_error("Index entry count exceeds available memory"))?;
 
         for _ in 0..count {
             let id_len = read_u32(&mut file)? as usize;
             if id_len == 0 {
                 return Err(invalid_index_error("Index entry has empty ID"));
             }
+            if id_len > MAX_INDEX_ID_BYTES {
+                return Err(invalid_index_error(
+                    "Index entry ID exceeds maximum supported size",
+                ));
+            }
             let mut id_bytes = vec![0u8; id_len];
-            file.read_exact(&mut id_bytes)?;
+            read_index_exact(&mut file, &mut id_bytes)?;
             let id = String::from_utf8(id_bytes)
                 .map_err(|_| invalid_index_error("Index entry has invalid UTF-8 ID"))?;
             let offset = read_u64(&mut file)?;
@@ -141,11 +333,17 @@ impl Index {
     ///
     /// Returns an error if the file cannot be written or renamed.
     pub fn save(&self) -> Result<()> {
-        use std::fs::File;
         use std::io::Write;
 
-        let temp_path = self.path.with_extension("bin.tmp");
-        let mut file = File::create(&temp_path)?;
+        Self::validate_path(&self.path)?;
+        let path = normalize_managed_path(&self.path, "Index file path")?;
+
+        let temp_path = unique_temp_path(&path, "bin");
+        reject_managed_path_symlinks(&temp_path, "Index temp file path")?;
+        let mut file = OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(&temp_path)?;
 
         file.write_all(&INDEX_MAGIC)?;
         file.write_all(&[INDEX_VERSION])?;
@@ -161,7 +359,8 @@ impl Index {
         }
 
         file.sync_all()?;
-        std::fs::rename(&temp_path, &self.path)?;
+        Self::validate_path(&path)?;
+        std::fs::rename(&temp_path, &path)?;
 
         Ok(())
     }
@@ -212,8 +411,7 @@ impl Index {
     ///
     /// Returns an error if the JSONL file cannot be read or contains invalid JSON.
     pub fn rebuild(&mut self, jsonl_path: &Path) -> Result<()> {
-        use std::fs::File;
-        use std::io::{BufRead, BufReader};
+        use std::io::BufReader;
 
         self.map.clear();
 
@@ -221,17 +419,32 @@ impl Index {
             return Ok(());
         }
 
-        let file = File::open(jsonl_path)?;
+        Storage::reject_symlink_path(jsonl_path)?;
+
+        let file = open_existing_no_follow(jsonl_path)?;
         let mut reader = BufReader::new(file);
         let mut offset: u64 = 0;
+        let mut line = Vec::new();
+        let mut line_idx = 0usize;
 
         loop {
-            let mut line = String::new();
-            let bytes = reader.read_line(&mut line)?;
+            let bytes = read_bounded_jsonl_line(&mut reader, jsonl_path, line_idx + 1, &mut line)?;
             if bytes == 0 {
                 break;
             }
+            line_idx += 1;
 
+            let line = std::str::from_utf8(&line).map_err(|err| {
+                Error::Io(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!(
+                        "Invalid UTF-8 in {} at line {}: {}",
+                        jsonl_path.display(),
+                        line_idx,
+                        err
+                    ),
+                ))
+            })?;
             let line_trimmed = line.trim_end_matches(['\n', '\r']);
             if line_trimmed.is_empty() {
                 offset = offset.saturating_add(bytes as u64);
@@ -294,6 +507,7 @@ impl Storage {
     /// Returns an error if the path is invalid.
     pub fn new(path: PathBuf) -> Result<Self> {
         Self::validate_path(&path)?;
+        let path = normalize_managed_path(&path, "Storage file path")?;
         Ok(Self { path, index: None })
     }
 
@@ -313,6 +527,7 @@ impl Storage {
     /// Returns an error if the path is invalid.
     pub fn with_index(path: PathBuf, index_path: Option<PathBuf>) -> Result<Self> {
         Self::validate_path(&path)?;
+        let path = normalize_managed_path(&path, "Storage file path")?;
         let mut index = None;
 
         if let Some(index_path) = index_path {
@@ -366,7 +581,16 @@ impl Storage {
                 "Path cannot be empty",
             )));
         }
+        Self::reject_symlink_path(path)?;
         Ok(())
+    }
+
+    fn reject_symlink_path(path: &Path) -> Result<()> {
+        reject_managed_path_symlinks(path, "Storage file path")
+    }
+
+    fn ensure_not_symlink(&self) -> Result<()> {
+        Self::reject_symlink_path(&self.path)
     }
 
     /// Returns a reference to the JSONL file path.
@@ -419,32 +643,133 @@ impl Storage {
     /// - The file contains invalid JSON
     /// - A Pearl fails validation
     pub fn load_all(&self) -> Result<Vec<Pearl>> {
-        use std::fs::File;
         use std::io::BufReader;
+
+        self.ensure_not_symlink()?;
 
         // Handle empty file case
         if !self.path.exists() {
             return Ok(Vec::new());
         }
 
-        let file = File::open(&self.path)?;
-        let reader = BufReader::with_capacity(64 * 1024, file);
+        let file = open_existing_no_follow(&self.path)?;
+        let mut reader = BufReader::with_capacity(64 * 1024, file);
         let mut pearls = Vec::new();
+        let mut line = Vec::new();
+        let mut line_idx = 0usize;
 
-        // Use streaming deserializer for memory efficiency
-        let stream = serde_json::Deserializer::from_reader(reader).into_iter::<Pearl>();
+        loop {
+            let bytes = read_bounded_jsonl_line(&mut reader, &self.path, line_idx + 1, &mut line)?;
+            if bytes == 0 {
+                break;
+            }
+            line_idx += 1;
 
-        for result in stream {
-            match result {
+            let line = match std::str::from_utf8(&line) {
+                Ok(line) => line,
+                Err(err) => {
+                    eprintln!(
+                        "Warning: Skipping invalid UTF-8 in {} at line {}: {}",
+                        self.path.display(),
+                        line_idx,
+                        err
+                    );
+                    continue;
+                }
+            };
+            let line_trimmed = line.trim_end_matches(['\n', '\r']);
+            if line_trimmed.is_empty() {
+                continue;
+            }
+
+            match serde_json::from_str::<Pearl>(line_trimmed) {
                 Ok(pearl) => {
                     pearl.validate()?;
                     pearls.push(pearl);
                 }
                 Err(e) => {
                     // Log malformed JSON but continue processing
-                    eprintln!("Warning: Skipping malformed JSON line: {}", e);
+                    eprintln!(
+                        "Warning: Skipping malformed JSON in {} at line {}: {}",
+                        self.path.display(),
+                        line_idx,
+                        e
+                    );
                 }
             }
+        }
+
+        Ok(pearls)
+    }
+
+    /// Loads all Pearls from the JSONL file and fails on malformed lines.
+    ///
+    /// Use this in write paths that depend on a complete ID reservation set.
+    /// The permissive [`Storage::load_all`] method is retained for existing
+    /// read/list behavior that tolerates partially malformed repositories.
+    pub fn load_all_strict(&self) -> Result<Vec<Pearl>> {
+        use std::io::BufReader;
+
+        self.ensure_not_symlink()?;
+
+        if !self.path.exists() {
+            return Ok(Vec::new());
+        }
+
+        let file = open_existing_no_follow(&self.path)?;
+        let mut reader = BufReader::with_capacity(64 * 1024, file);
+        let mut pearls = Vec::new();
+        let mut seen_ids = HashSet::new();
+        let mut line = Vec::new();
+        let mut line_idx = 0usize;
+
+        loop {
+            let bytes = read_bounded_jsonl_line(&mut reader, &self.path, line_idx + 1, &mut line)?;
+            if bytes == 0 {
+                break;
+            }
+            line_idx += 1;
+
+            let line = std::str::from_utf8(&line).map_err(|err| {
+                Error::Io(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!(
+                        "Invalid UTF-8 in {} at line {}: {}",
+                        self.path.display(),
+                        line_idx,
+                        err
+                    ),
+                ))
+            })?;
+            let line_trimmed = line.trim_end_matches(['\n', '\r']);
+            if line_trimmed.is_empty() {
+                continue;
+            }
+
+            let pearl: Pearl = serde_json::from_str(line_trimmed).map_err(|err| {
+                Error::Io(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!(
+                        "Invalid Pearl JSON in {} at line {}: {}",
+                        self.path.display(),
+                        line_idx,
+                        err
+                    ),
+                ))
+            })?;
+            pearl.validate()?;
+            if !seen_ids.insert(pearl.id.clone()) {
+                return Err(Error::Io(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!(
+                        "Duplicate Pearl ID in {} at line {}: {}",
+                        self.path.display(),
+                        line_idx,
+                        pearl.id
+                    ),
+                )));
+            }
+            pearls.push(pearl);
         }
 
         Ok(pearls)
@@ -467,8 +792,9 @@ impl Storage {
     /// - The Pearl is not found
     /// - The file contains invalid JSON
     pub fn load_by_id(&mut self, id: &str) -> Result<Pearl> {
-        use std::fs::File;
         use std::io::BufReader;
+
+        self.ensure_not_symlink()?;
 
         // Check index first if available
         if let Some(index) = self.index.as_mut() {
@@ -493,12 +819,36 @@ impl Storage {
             return Err(Error::NotFound(id.to_string()));
         }
 
-        let file = File::open(&self.path)?;
-        let reader = BufReader::with_capacity(64 * 1024, file);
-        let stream = serde_json::Deserializer::from_reader(reader).into_iter::<Pearl>();
+        let file = open_existing_no_follow(&self.path)?;
+        let mut reader = BufReader::with_capacity(64 * 1024, file);
+        let mut line = Vec::new();
+        let mut line_idx = 0usize;
 
-        for result in stream {
-            match result {
+        loop {
+            let bytes = read_bounded_jsonl_line(&mut reader, &self.path, line_idx + 1, &mut line)?;
+            if bytes == 0 {
+                break;
+            }
+            line_idx += 1;
+
+            let line = match std::str::from_utf8(&line) {
+                Ok(line) => line,
+                Err(err) => {
+                    eprintln!(
+                        "Warning: Skipping invalid UTF-8 in {} at line {}: {}",
+                        self.path.display(),
+                        line_idx,
+                        err
+                    );
+                    continue;
+                }
+            };
+            let line_trimmed = line.trim_end_matches(['\n', '\r']);
+            if line_trimmed.is_empty() {
+                continue;
+            }
+
+            match serde_json::from_str::<Pearl>(line_trimmed) {
                 Ok(pearl) => {
                     if pearl.id == id {
                         pearl.validate()?;
@@ -506,8 +856,12 @@ impl Storage {
                     }
                 }
                 Err(e) => {
-                    // Skip malformed JSON lines
-                    eprintln!("Warning: Skipping malformed JSON line: {}", e);
+                    eprintln!(
+                        "Warning: Skipping malformed JSON in {} at line {}: {}",
+                        self.path.display(),
+                        line_idx,
+                        e
+                    );
                 }
             }
         }
@@ -516,19 +870,31 @@ impl Storage {
     }
 
     fn load_by_offset(path: &Path, id: &str, offset: u64) -> Result<Pearl> {
-        use std::fs::File;
-        use std::io::{BufRead, BufReader, Seek, SeekFrom};
+        use std::io::{BufReader, Seek, SeekFrom};
 
-        let mut file = File::open(path)?;
+        Self::reject_symlink_path(path)?;
+
+        let mut file = open_existing_no_follow(path)?;
         file.seek(SeekFrom::Start(offset))?;
 
         let mut reader = BufReader::new(file);
-        let mut line = String::new();
-        let bytes = reader.read_line(&mut line)?;
+        let mut line = Vec::new();
+        let bytes = read_bounded_jsonl_line(&mut reader, path, 1, &mut line)?;
         if bytes == 0 {
             return Err(Error::NotFound(id.to_string()));
         }
 
+        let line = std::str::from_utf8(&line).map_err(|err| {
+            Error::Io(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "Invalid UTF-8 in {} at offset {}: {}",
+                    path.display(),
+                    offset,
+                    err
+                ),
+            ))
+        })?;
         let line_trimmed = line.trim_end_matches(['\n', '\r']);
         if line_trimmed.is_empty() {
             return Err(Error::NotFound(id.to_string()));
@@ -579,26 +945,46 @@ impl Storage {
         archive_path: Option<&Path>,
         max_attempts: u32,
     ) -> Result<()> {
-        if ReentrantLockGuard::is_held(&self.path.with_extension("lock")) {
+        self.create_many(std::slice::from_mut(pearl), archive_path, max_attempts)
+    }
+
+    /// Creates multiple Pearls with unused IDs in one locked write transaction.
+    ///
+    /// Unlike [`Storage::save_all`], this is create-only: it never updates
+    /// existing Pearls. Candidate IDs are checked while the storage lock is
+    /// held, including archived IDs when an archive path is provided.
+    pub fn create_many(
+        &mut self,
+        pearls: &mut [Pearl],
+        archive_path: Option<&Path>,
+        max_attempts: u32,
+    ) -> Result<()> {
+        if ReentrantLockGuard::is_held(&normalize_lock_path(self.path.with_extension("lock"))) {
             return Err(Error::InvalidPearl(
-                "create_new cannot be called while the storage file lock is already held"
+                "create_many cannot be called while the storage file lock is already held"
                     .to_string(),
             ));
         }
 
-        let mut pearl_to_save = pearl.clone();
+        let mut pearls_to_save = pearls.to_vec();
         let archive_path = archive_path.map(Path::to_path_buf);
 
         let repository_lock_path = self.repository_lock_path();
         let saved = Self::with_exclusive_lock_path(repository_lock_path, move || {
             self.with_lock(move |storage| {
                 storage
-                    .create_new_unlocked(&mut pearl_to_save, archive_path.as_deref(), max_attempts)
-                    .map(|()| pearl_to_save)
+                    .create_many_unlocked(
+                        &mut pearls_to_save,
+                        archive_path.as_deref(),
+                        max_attempts,
+                    )
+                    .map(|()| pearls_to_save)
             })
         })?;
 
-        pearl.id = saved.id;
+        for (target, saved) in pearls.iter_mut().zip(saved) {
+            target.id = saved.id;
+        }
         Ok(())
     }
 
@@ -685,18 +1071,24 @@ impl Storage {
         use fs2::FileExt;
         use std::time::{Duration, Instant};
 
+        let lock_path = normalize_lock_path(lock_path);
+        reject_managed_path_symlinks(&lock_path, "Lock file path").map_err(E::from)?;
+
+        if Self::is_repository_lock_path(&lock_path)
+            && ReentrantLockGuard::is_any_other_held(&lock_path)
+        {
+            return Err(E::from(Error::InvalidPearl(
+                "repository lock cannot be acquired while another storage lock is already held"
+                    .to_string(),
+            )));
+        }
+
         let reentrant_guard = ReentrantLockGuard::acquire(lock_path.clone());
         if reentrant_guard.was_held() {
             return f();
         }
 
-        let lock_file = OpenOptions::new()
-            .create(true)
-            .read(true)
-            .write(true)
-            .truncate(false)
-            .open(&lock_path)
-            .map_err(|err| E::from(Error::Io(err)))?;
+        let lock_file = open_lock_no_follow(&lock_path).map_err(E::from)?;
 
         // Try to acquire exclusive lock with timeout.
         // fs2 does not support timeouts directly, so we retry with backoff.
@@ -724,6 +1116,11 @@ impl Storage {
         let _ = lock_file.unlock();
 
         result
+    }
+
+    fn is_repository_lock_path(path: &Path) -> bool {
+        path.file_name()
+            .is_some_and(|name| name == "repository.lock")
     }
 }
 
@@ -753,6 +1150,10 @@ impl ReentrantLockGuard {
 
     fn is_held(path: &Path) -> bool {
         REENTRANT_LOCK_DEPTHS.with(|locks| locks.borrow().contains_key(path))
+    }
+
+    fn is_any_other_held(path: &Path) -> bool {
+        REENTRANT_LOCK_DEPTHS.with(|locks| locks.borrow().keys().any(|held| held != path))
     }
 }
 
@@ -793,7 +1194,7 @@ impl Storage {
         let target_id = id.to_string();
         self.with_lock(move |storage| {
             // Load all Pearls
-            let mut pearls = storage.load_all()?;
+            let mut pearls = storage.load_all_strict()?;
 
             // Find and remove the Pearl
             let initial_len = pearls.len();
@@ -834,9 +1235,9 @@ impl Storage {
 }
 
 impl Storage {
-    fn create_new_unlocked(
+    fn create_many_unlocked(
         &mut self,
-        pearl: &mut Pearl,
+        new_pearls: &mut [Pearl],
         archive_path: Option<&Path>,
         max_attempts: u32,
     ) -> Result<()> {
@@ -846,40 +1247,54 @@ impl Storage {
             ));
         }
 
-        let mut pearls = self.load_all()?;
+        let mut pearls = self.load_all_strict()?;
         let mut reserved_ids: HashSet<String> = pearls.iter().map(|p| p.id.clone()).collect();
 
         if let Some(archive_path) = archive_path.filter(|path| path.exists()) {
             let archive_storage = Storage::new(archive_path.to_path_buf())?;
-            for archived in archive_storage.load_all()? {
+            for archived in archive_storage.load_all_strict()? {
                 reserved_ids.insert(archived.id);
             }
         }
 
-        for nonce in 0..max_attempts {
-            let candidate =
-                crate::identity::generate_id(&pearl.title, &pearl.author, pearl.created_at, nonce);
+        for pearl in new_pearls {
+            let mut selected = None;
+            for nonce in 0..max_attempts {
+                let candidate = crate::identity::generate_id(
+                    &pearl.title,
+                    &pearl.author,
+                    pearl.created_at,
+                    nonce,
+                );
 
-            if reserved_ids.contains(&candidate) {
-                continue;
+                if reserved_ids.contains(&candidate) {
+                    continue;
+                }
+
+                selected = Some(candidate);
+                break;
             }
 
-            pearl.id = candidate;
+            let Some(candidate) = selected else {
+                return Err(Error::InvalidPearl(format!(
+                    "Unable to allocate unique Pearl ID after {max_attempts} attempts: candidate space exhausted"
+                )));
+            };
+
+            pearl.id = candidate.clone();
             pearl.validate()?;
+            reserved_ids.insert(candidate);
             pearls.push(pearl.clone());
-            return self.save_all_unlocked(&pearls);
         }
 
-        Err(Error::InvalidPearl(format!(
-            "Unable to allocate unique Pearl ID after {max_attempts} attempts: candidate space exhausted"
-        )))
+        self.save_all_unlocked(&pearls)
     }
 
     fn save_unlocked(&mut self, pearl: &Pearl) -> Result<()> {
         pearl.validate()?;
 
         // Load all existing Pearls while lock is held.
-        let mut pearls = self.load_all().unwrap_or_default();
+        let mut pearls = self.load_all_strict()?;
 
         // Find and update or append.
         if let Some(pos) = pearls.iter().position(|p| p.id == pearl.id) {
@@ -893,6 +1308,8 @@ impl Storage {
 
     fn save_all_unlocked(&mut self, pearls: &[Pearl]) -> Result<()> {
         use std::io::Write;
+
+        self.ensure_not_symlink()?;
 
         // Validate all Pearls first.
         for pearl in pearls {
@@ -950,11 +1367,6 @@ impl Storage {
     }
 
     fn unique_temp_path(&self) -> PathBuf {
-        let counter = TEMP_FILE_COUNTER.fetch_add(1, Ordering::Relaxed);
-        let nanos = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map_or(0_u128, |duration| duration.as_nanos());
-        let temp_extension = format!("jsonl.tmp.{}.{}.{}", std::process::id(), nanos, counter);
-        self.path.with_extension(temp_extension)
+        unique_temp_path(&self.path, "jsonl")
     }
 }

--- a/crates/pearls-core/src/storage.rs
+++ b/crates/pearls-core/src/storage.rs
@@ -579,13 +579,23 @@ impl Storage {
         archive_path: Option<&Path>,
         max_attempts: u32,
     ) -> Result<()> {
+        if ReentrantLockGuard::is_held(&self.path.with_extension("lock")) {
+            return Err(Error::InvalidPearl(
+                "create_new cannot be called while the storage file lock is already held"
+                    .to_string(),
+            ));
+        }
+
         let mut pearl_to_save = pearl.clone();
         let archive_path = archive_path.map(Path::to_path_buf);
 
-        let saved = self.with_lock(move |storage| {
-            storage
-                .create_new_unlocked(&mut pearl_to_save, archive_path.as_deref(), max_attempts)
-                .map(|()| pearl_to_save)
+        let repository_lock_path = self.repository_lock_path();
+        let saved = Self::with_exclusive_lock_path(repository_lock_path, move || {
+            self.with_lock(move |storage| {
+                storage
+                    .create_new_unlocked(&mut pearl_to_save, archive_path.as_deref(), max_attempts)
+                    .map(|()| pearl_to_save)
+            })
         })?;
 
         pearl.id = saved.id;
@@ -643,14 +653,41 @@ impl Storage {
         F: FnOnce(&mut Storage) -> std::result::Result<T, E>,
         E: From<Error>,
     {
+        let lock_path = self.path.with_extension("lock");
+        Self::with_exclusive_lock_path(lock_path, move || f(self))
+    }
+
+    /// Executes a closure while holding the repository-level Pearls lock.
+    ///
+    /// Use this for operations that must coordinate multiple Pearls files, such
+    /// as active issues plus archives. Single-file operations should use
+    /// [`Storage::with_lock`].
+    pub fn with_repository_lock<F, T, E>(&self, f: F) -> std::result::Result<T, E>
+    where
+        F: FnOnce() -> std::result::Result<T, E>,
+        E: From<Error>,
+    {
+        Self::with_exclusive_lock_path(self.repository_lock_path(), f)
+    }
+
+    fn repository_lock_path(&self) -> PathBuf {
+        self.path.parent().map_or_else(
+            || self.path.with_extension("repository.lock"),
+            |parent| parent.join("repository.lock"),
+        )
+    }
+
+    fn with_exclusive_lock_path<F, T, E>(lock_path: PathBuf, f: F) -> std::result::Result<T, E>
+    where
+        F: FnOnce() -> std::result::Result<T, E>,
+        E: From<Error>,
+    {
         use fs2::FileExt;
         use std::time::{Duration, Instant};
 
-        // Create or open the lock file
-        let lock_path = self.path.with_extension("lock");
         let reentrant_guard = ReentrantLockGuard::acquire(lock_path.clone());
         if reentrant_guard.was_held() {
-            return f(self);
+            return f();
         }
 
         let lock_file = OpenOptions::new()
@@ -681,7 +718,7 @@ impl Storage {
         }
 
         // Execute the closure
-        let result = f(self);
+        let result = f();
 
         // Ensure lock is released (even if closure fails)
         let _ = lock_file.unlock();
@@ -712,6 +749,10 @@ impl ReentrantLockGuard {
 
     fn was_held(&self) -> bool {
         self.was_held
+    }
+
+    fn is_held(path: &Path) -> bool {
+        REENTRANT_LOCK_DEPTHS.with(|locks| locks.borrow().contains_key(path))
     }
 }
 

--- a/crates/pearls-core/src/storage.rs
+++ b/crates/pearls-core/src/storage.rs
@@ -7,7 +7,7 @@
 
 use crate::{Error, Pearl, Result};
 use std::cell::RefCell;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs::OpenOptions;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -568,6 +568,30 @@ impl Storage {
         self.with_lock(move |storage| storage.save_unlocked(&pearl_to_save))
     }
 
+    /// Creates a new Pearl with an unused ID.
+    ///
+    /// Unlike [`Storage::save`], this is create-only: it never updates an
+    /// existing Pearl. Candidate IDs are checked while the storage lock is held,
+    /// including archived IDs when an archive path is provided.
+    pub fn create_new(
+        &mut self,
+        pearl: &mut Pearl,
+        archive_path: Option<&Path>,
+        max_attempts: u32,
+    ) -> Result<()> {
+        let mut pearl_to_save = pearl.clone();
+        let archive_path = archive_path.map(Path::to_path_buf);
+
+        let saved = self.with_lock(move |storage| {
+            storage
+                .create_new_unlocked(&mut pearl_to_save, archive_path.as_deref(), max_attempts)
+                .map(|()| pearl_to_save)
+        })?;
+
+        pearl.id = saved.id;
+        Ok(())
+    }
+
     /// Saves multiple Pearls to the JSONL file.
     ///
     /// Replaces the entire file with the provided Pearls.
@@ -769,6 +793,47 @@ impl Storage {
 }
 
 impl Storage {
+    fn create_new_unlocked(
+        &mut self,
+        pearl: &mut Pearl,
+        archive_path: Option<&Path>,
+        max_attempts: u32,
+    ) -> Result<()> {
+        if max_attempts == 0 {
+            return Err(Error::InvalidPearl(
+                "Unable to allocate unique Pearl ID: candidate space exhausted".to_string(),
+            ));
+        }
+
+        let mut pearls = self.load_all()?;
+        let mut reserved_ids: HashSet<String> = pearls.iter().map(|p| p.id.clone()).collect();
+
+        if let Some(archive_path) = archive_path.filter(|path| path.exists()) {
+            let archive_storage = Storage::new(archive_path.to_path_buf())?;
+            for archived in archive_storage.load_all()? {
+                reserved_ids.insert(archived.id);
+            }
+        }
+
+        for nonce in 0..max_attempts {
+            let candidate =
+                crate::identity::generate_id(&pearl.title, &pearl.author, pearl.created_at, nonce);
+
+            if reserved_ids.contains(&candidate) {
+                continue;
+            }
+
+            pearl.id = candidate;
+            pearl.validate()?;
+            pearls.push(pearl.clone());
+            return self.save_all_unlocked(&pearls);
+        }
+
+        Err(Error::InvalidPearl(format!(
+            "Unable to allocate unique Pearl ID after {max_attempts} attempts: candidate space exhausted"
+        )))
+    }
+
     fn save_unlocked(&mut self, pearl: &Pearl) -> Result<()> {
         pearl.validate()?;
 

--- a/crates/pearls-core/tests/models_props.rs
+++ b/crates/pearls-core/tests/models_props.rs
@@ -56,7 +56,7 @@ fn arb_pearl() -> impl Strategy<Value = Pearl> {
         prop::collection::vec(arb_dependency(), 0..5),
         prop::collection::hash_map(
             prop::string::string_regex("[a-z_]{1,20}").unwrap(),
-            any::<String>().prop_map(|s| serde_json::Value::String(s)),
+            any::<String>().prop_map(serde_json::Value::String),
             0..5,
         ),
     )

--- a/crates/pearls-core/tests/storage_props.rs
+++ b/crates/pearls-core/tests/storage_props.rs
@@ -56,7 +56,7 @@ fn arb_pearl() -> impl Strategy<Value = Pearl> {
         ),
         prop::collection::hash_map(
             prop::string::string_regex("[a-z_]{1,20}").unwrap(),
-            any::<String>().prop_map(|s| serde_json::Value::String(s)),
+            any::<String>().prop_map(serde_json::Value::String),
             0..3,
         ),
     )

--- a/crates/pearls-core/tests/storage_tests.rs
+++ b/crates/pearls-core/tests/storage_tests.rs
@@ -4,7 +4,7 @@
 //!
 //! These tests validate specific examples, edge cases, and error conditions.
 
-use pearls_core::{Pearl, Status, Storage};
+use pearls_core::{identity::generate_id, Error, Pearl, Status, Storage};
 use std::fs;
 use tempfile::TempDir;
 
@@ -24,6 +24,111 @@ fn create_test_pearl(id: &str, title: &str) -> Pearl {
         metadata: Default::default(),
         comments: Vec::new(),
     }
+}
+
+fn create_collision_pearl(title: &str, author: &str, timestamp: i64) -> Pearl {
+    Pearl {
+        id: generate_id(title, author, timestamp, 0),
+        title: title.to_string(),
+        description: String::new(),
+        status: Status::Open,
+        priority: 2,
+        created_at: timestamp,
+        updated_at: timestamp,
+        author: author.to_string(),
+        labels: vec![],
+        deps: vec![],
+        metadata: Default::default(),
+        comments: Vec::new(),
+    }
+}
+
+#[test]
+fn test_create_new_retries_active_id_collision() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let storage_path = temp_dir.path().join("issues.jsonl");
+    let archive_path = temp_dir.path().join("archive.jsonl");
+    let mut storage = Storage::new(storage_path).expect("Failed to create storage");
+
+    let mut first = create_collision_pearl("Duplicate title", "author", 1704067200);
+    let mut second = create_collision_pearl("Duplicate title", "author", 1704067200);
+    let first_nonce_zero_id = first.id.clone();
+    assert_eq!(first.id, second.id, "fixture should start with a collision");
+
+    storage
+        .create_new(&mut first, Some(&archive_path), 2)
+        .expect("Failed to create first pearl");
+    storage
+        .create_new(&mut second, Some(&archive_path), 2)
+        .expect("Failed to create second pearl");
+
+    let pearls = storage.load_all().expect("Failed to load pearls");
+    assert_eq!(pearls.len(), 2, "create should append both pearls");
+    assert_eq!(first.id, first_nonce_zero_id);
+    assert_ne!(first.id, second.id, "second create should retry nonce");
+    assert_eq!(
+        second.id,
+        generate_id("Duplicate title", "author", 1704067200, 1)
+    );
+}
+
+#[test]
+fn test_create_new_reserves_archived_ids() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let storage_path = temp_dir.path().join("issues.jsonl");
+    let archive_path = temp_dir.path().join("archive.jsonl");
+
+    let archived = create_collision_pearl("Archived title", "author", 1704067200);
+    let archived_id = archived.id.clone();
+    let mut archive_storage = Storage::new(archive_path.clone()).expect("Failed to create archive");
+    archive_storage
+        .save(&archived)
+        .expect("Failed to save archived pearl");
+
+    let mut storage = Storage::new(storage_path).expect("Failed to create storage");
+    let mut active = create_collision_pearl("Archived title", "author", 1704067200);
+    storage
+        .create_new(&mut active, Some(&archive_path), 2)
+        .expect("Failed to create active pearl");
+
+    assert_ne!(
+        active.id, archived_id,
+        "create should not reuse archived IDs"
+    );
+    assert_eq!(
+        active.id,
+        generate_id("Archived title", "author", 1704067200, 1)
+    );
+}
+
+#[test]
+fn test_create_new_fails_explicitly_when_candidates_exhausted() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let storage_path = temp_dir.path().join("issues.jsonl");
+    let archive_path = temp_dir.path().join("archive.jsonl");
+    let mut storage = Storage::new(storage_path).expect("Failed to create storage");
+
+    let mut first = create_collision_pearl("Exhaust title", "author", 1704067200);
+    let mut second = create_collision_pearl("Exhaust title", "author", 1704067200);
+    storage
+        .create_new(&mut first, Some(&archive_path), 1)
+        .expect("Failed to create first pearl");
+
+    let err = storage
+        .create_new(&mut second, Some(&archive_path), 1)
+        .expect_err("Exhausted candidate generation should fail");
+
+    assert!(
+        matches!(err, Error::InvalidPearl(ref message) if message.contains("candidate space exhausted")),
+        "unexpected error: {err}"
+    );
+
+    let pearls = storage.load_all().expect("Failed to load pearls");
+    assert_eq!(
+        pearls.len(),
+        1,
+        "failed create must not overwrite existing pearl"
+    );
 }
 
 #[test]

--- a/crates/pearls-core/tests/storage_tests.rs
+++ b/crates/pearls-core/tests/storage_tests.rs
@@ -4,7 +4,7 @@
 //!
 //! These tests validate specific examples, edge cases, and error conditions.
 
-use pearls_core::{identity::generate_id, Error, Pearl, Status, Storage};
+use pearls_core::{identity::generate_id, storage::Index, Error, Pearl, Status, Storage};
 use std::fs;
 use std::sync::mpsc;
 use std::thread;
@@ -244,6 +244,361 @@ fn test_create_new_rejects_call_inside_storage_file_lock() {
 
     assert!(
         matches!(err, Error::InvalidPearl(ref message) if message.contains("storage file lock is already held")),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn test_save_fails_closed_on_malformed_active_jsonl() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let storage_path = temp_dir.path().join("issues.jsonl");
+    fs::write(&storage_path, "{not valid json}\n").expect("Failed to write malformed issues");
+    let mut storage = Storage::new(storage_path).expect("Failed to create storage");
+    let pearl = create_test_pearl("prl-111111", "Replacement");
+
+    let err = storage
+        .save(&pearl)
+        .expect_err("save should fail closed on malformed active JSONL");
+
+    assert!(
+        matches!(err, Error::Io(ref io_err) if io_err.kind() == std::io::ErrorKind::InvalidData),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn test_delete_fails_closed_on_malformed_active_jsonl() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let storage_path = temp_dir.path().join("issues.jsonl");
+    let original = "{not valid json}\n";
+    fs::write(&storage_path, original).expect("Failed to write malformed issues");
+    let mut storage = Storage::new(storage_path.clone()).expect("Failed to create storage");
+
+    let err = storage
+        .delete("prl-111111")
+        .expect_err("delete should fail closed on malformed active JSONL");
+
+    assert!(
+        matches!(err, Error::Io(ref io_err) if io_err.kind() == std::io::ErrorKind::InvalidData),
+        "unexpected error: {err}"
+    );
+    assert_eq!(
+        fs::read_to_string(storage_path).expect("Failed to reread issues"),
+        original
+    );
+}
+
+#[test]
+fn test_load_all_strict_rejects_oversized_line() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let storage_path = temp_dir.path().join("issues.jsonl");
+    let oversized = "{".to_string() + &"x".repeat(17 * 1024 * 1024);
+    fs::write(&storage_path, oversized).expect("Failed to write oversized line");
+    let storage = Storage::new(storage_path).expect("Failed to create storage");
+
+    let err = storage
+        .load_all_strict()
+        .expect_err("strict load should reject oversized JSONL line");
+
+    assert!(
+        matches!(err, Error::Io(ref io_err) if io_err.kind() == std::io::ErrorKind::InvalidData),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn test_load_all_rejects_oversized_line() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let storage_path = temp_dir.path().join("issues.jsonl");
+    let oversized = "{".to_string() + &"x".repeat(17 * 1024 * 1024);
+    fs::write(&storage_path, oversized).expect("Failed to write oversized line");
+    let storage = Storage::new(storage_path).expect("Failed to create storage");
+
+    let err = storage
+        .load_all()
+        .expect_err("permissive load should still reject oversized JSONL line");
+
+    assert!(
+        matches!(err, Error::Io(ref io_err) if io_err.kind() == std::io::ErrorKind::InvalidData),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn test_load_by_id_rejects_oversized_line() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let storage_path = temp_dir.path().join("issues.jsonl");
+    let oversized = "{".to_string() + &"x".repeat(17 * 1024 * 1024);
+    fs::write(&storage_path, oversized).expect("Failed to write oversized line");
+    let mut storage = Storage::new(storage_path).expect("Failed to create storage");
+
+    let err = storage
+        .load_by_id("prl-111111")
+        .expect_err("load_by_id should reject oversized JSONL line");
+
+    assert!(
+        matches!(err, Error::Io(ref io_err) if io_err.kind() == std::io::ErrorKind::InvalidData),
+        "unexpected error: {err}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_storage_rejects_symlink_path() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let target_path = temp_dir.path().join("target.jsonl");
+    let symlink_path = temp_dir.path().join("issues.jsonl");
+    fs::write(&target_path, "").expect("Failed to write target");
+    std::os::unix::fs::symlink(&target_path, &symlink_path).expect("Failed to create symlink");
+
+    let err = match Storage::new(symlink_path) {
+        Ok(_) => panic!("Storage should reject symlinked JSONL path"),
+        Err(err) => err,
+    };
+
+    assert!(
+        matches!(err, Error::Io(ref io_err) if io_err.kind() == std::io::ErrorKind::InvalidInput),
+        "unexpected error: {err}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_storage_write_rejects_path_that_becomes_symlink() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let storage_path = temp_dir.path().join("issues.jsonl");
+    let target_path = temp_dir.path().join("target.jsonl");
+    let mut storage = Storage::new(storage_path.clone()).expect("Failed to create storage");
+    fs::write(&target_path, "").expect("Failed to write target");
+    std::os::unix::fs::symlink(&target_path, &storage_path).expect("Failed to create symlink");
+
+    let pearl = create_test_pearl("prl-111111", "Symlink write");
+    let err = storage
+        .save(&pearl)
+        .expect_err("Storage write should reject symlinked JSONL path");
+
+    assert!(
+        matches!(err, Error::Io(ref io_err) if io_err.kind() == std::io::ErrorKind::InvalidInput),
+        "unexpected error: {err}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_storage_with_index_rejects_symlink_index_path() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let storage_path = temp_dir.path().join("issues.jsonl");
+    let index_target = temp_dir.path().join("target.idx");
+    let index_path = temp_dir.path().join("issues.idx");
+    fs::write(&storage_path, "").expect("Failed to write storage");
+    fs::write(&index_target, "").expect("Failed to write index target");
+    std::os::unix::fs::symlink(&index_target, &index_path).expect("Failed to create symlink");
+
+    let err = match Storage::with_index(storage_path, Some(index_path)) {
+        Ok(_) => panic!("Storage should reject symlinked index path"),
+        Err(err) => err,
+    };
+
+    assert!(
+        matches!(err, Error::Io(ref io_err) if io_err.kind() == std::io::ErrorKind::InvalidInput),
+        "unexpected error: {err}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_enable_index_rejects_symlink_index_path() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let storage_path = temp_dir.path().join("issues.jsonl");
+    let index_target = temp_dir.path().join("target.idx");
+    let index_path = temp_dir.path().join("issues.idx");
+    fs::write(&storage_path, "").expect("Failed to write storage");
+    fs::write(&index_target, "").expect("Failed to write index target");
+    std::os::unix::fs::symlink(&index_target, &index_path).expect("Failed to create symlink");
+    let mut storage = Storage::new(storage_path).expect("Failed to create storage");
+
+    let err = storage
+        .enable_index(index_path)
+        .expect_err("enable_index should reject symlinked index path");
+
+    assert!(
+        matches!(err, Error::Io(ref io_err) if io_err.kind() == std::io::ErrorKind::InvalidInput),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn test_index_load_rejects_huge_entry_count() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let index_path = temp_dir.path().join("issues.idx");
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(b"PRLIDX1\0");
+    bytes.push(1);
+    bytes.extend_from_slice(&u64::MAX.to_le_bytes());
+    fs::write(&index_path, bytes).expect("Failed to write malformed index");
+
+    let err = Index::load(index_path).expect_err("Index should reject huge entry count");
+
+    assert!(
+        matches!(err, Error::Io(ref io_err) if io_err.kind() == std::io::ErrorKind::InvalidData),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn test_index_load_rejects_huge_id_length() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let index_path = temp_dir.path().join("issues.idx");
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(b"PRLIDX1\0");
+    bytes.push(1);
+    bytes.extend_from_slice(&1_u64.to_le_bytes());
+    bytes.extend_from_slice(&u32::MAX.to_le_bytes());
+    fs::write(&index_path, bytes).expect("Failed to write malformed index");
+
+    let err = Index::load(index_path).expect_err("Index should reject huge ID length");
+
+    assert!(
+        matches!(err, Error::Io(ref io_err) if io_err.kind() == std::io::ErrorKind::InvalidData),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn test_index_load_treats_truncated_file_as_invalid_data() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let index_path = temp_dir.path().join("issues.idx");
+    fs::write(&index_path, b"PRLIDX1\0").expect("Failed to write truncated index");
+
+    let err = Index::load(index_path).expect_err("Index should reject truncated file");
+
+    assert!(
+        matches!(err, Error::Io(ref io_err) if io_err.kind() == std::io::ErrorKind::InvalidData),
+        "unexpected error: {err}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_storage_write_rejects_symlink_lock_file() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let storage_path = temp_dir.path().join("issues.jsonl");
+    let lock_target = temp_dir.path().join("target.lock");
+    let lock_path = storage_path.with_extension("lock");
+    fs::write(&lock_target, "").expect("Failed to write lock target");
+    std::os::unix::fs::symlink(&lock_target, &lock_path).expect("Failed to create lock symlink");
+    let mut storage = Storage::new(storage_path).expect("Failed to create storage");
+    let pearl = create_test_pearl("prl-111111", "Symlink lock");
+
+    let err = storage
+        .save(&pearl)
+        .expect_err("Storage write should reject symlinked lock path");
+
+    assert!(
+        matches!(err, Error::Io(ref io_err) if io_err.kind() == std::io::ErrorKind::InvalidInput),
+        "unexpected error: {err}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_repository_lock_rejects_symlink_lock_file() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let storage_path = temp_dir.path().join("issues.jsonl");
+    let repo_lock_target = temp_dir.path().join("target-repository.lock");
+    let repo_lock_path = temp_dir.path().join("repository.lock");
+    fs::write(&repo_lock_target, "").expect("Failed to write lock target");
+    std::os::unix::fs::symlink(&repo_lock_target, &repo_lock_path)
+        .expect("Failed to create repository lock symlink");
+    let storage = Storage::new(storage_path).expect("Failed to create storage");
+
+    let err = storage
+        .with_repository_lock(|| Ok::<(), Error>(()))
+        .expect_err("Repository lock should reject symlinked lock path");
+
+    assert!(
+        matches!(err, Error::Io(ref io_err) if io_err.kind() == std::io::ErrorKind::InvalidInput),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn test_load_all_strict_rejects_duplicate_ids() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let storage_path = temp_dir.path().join("issues.jsonl");
+    let first = create_test_pearl("prl-111111", "First");
+    let second = create_test_pearl("prl-111111", "Second");
+    fs::write(
+        &storage_path,
+        format!(
+            "{}\n{}\n",
+            serde_json::to_string(&first).expect("serialize first"),
+            serde_json::to_string(&second).expect("serialize second")
+        ),
+    )
+    .expect("Failed to write duplicate IDs");
+    let storage = Storage::new(storage_path).expect("Failed to create storage");
+
+    let err = storage
+        .load_all_strict()
+        .expect_err("strict load should reject duplicate IDs");
+
+    assert!(
+        matches!(err, Error::Io(ref io_err) if io_err.kind() == std::io::ErrorKind::InvalidData),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn test_repository_lock_rejects_call_inside_storage_file_lock() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let storage_path = temp_dir.path().join("issues.jsonl");
+    let mut storage = Storage::new(storage_path).expect("Failed to create storage");
+
+    let err = storage
+        .with_lock(|storage| storage.with_repository_lock(|| Ok::<(), Error>(())))
+        .expect_err("repository lock inside with_lock should fail to avoid lock-order inversion");
+
+    assert!(
+        matches!(err, Error::InvalidPearl(ref message) if message.contains("repository lock cannot be acquired")),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn test_create_new_fails_closed_on_malformed_active_jsonl() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let storage_path = temp_dir.path().join("issues.jsonl");
+    let archive_path = temp_dir.path().join("archive.jsonl");
+    fs::write(&storage_path, "{not valid json}\n").expect("Failed to write malformed issues");
+    let mut storage = Storage::new(storage_path).expect("Failed to create storage");
+    let mut pearl = create_collision_pearl("Malformed active", "author", 1704067200);
+
+    let err = storage
+        .create_new(&mut pearl, Some(&archive_path), 2)
+        .expect_err("create_new should fail closed on malformed active JSONL");
+
+    assert!(
+        matches!(err, Error::Io(ref io_err) if io_err.kind() == std::io::ErrorKind::InvalidData),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn test_create_new_fails_closed_on_malformed_archive_jsonl() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let storage_path = temp_dir.path().join("issues.jsonl");
+    let archive_path = temp_dir.path().join("archive.jsonl");
+    fs::write(&archive_path, "{not valid json}\n").expect("Failed to write malformed archive");
+    let mut storage = Storage::new(storage_path).expect("Failed to create storage");
+    let mut pearl = create_collision_pearl("Malformed archive", "author", 1704067200);
+
+    let err = storage
+        .create_new(&mut pearl, Some(&archive_path), 2)
+        .expect_err("create_new should fail closed on malformed archive JSONL");
+
+    assert!(
+        matches!(err, Error::Io(ref io_err) if io_err.kind() == std::io::ErrorKind::InvalidData),
         "unexpected error: {err}"
     );
 }

--- a/crates/pearls-core/tests/storage_tests.rs
+++ b/crates/pearls-core/tests/storage_tests.rs
@@ -6,6 +6,9 @@
 
 use pearls_core::{identity::generate_id, Error, Pearl, Status, Storage};
 use std::fs;
+use std::sync::mpsc;
+use std::thread;
+use std::time::{Duration, Instant};
 use tempfile::TempDir;
 
 /// Helper to create a test Pearl.
@@ -128,6 +131,120 @@ fn test_create_new_fails_explicitly_when_candidates_exhausted() {
         pearls.len(),
         1,
         "failed create must not overwrite existing pearl"
+    );
+}
+
+#[test]
+fn test_create_new_waits_for_repository_lock() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let storage_path = temp_dir.path().join("issues.jsonl");
+    let archive_path = temp_dir.path().join("archive.jsonl");
+    let lock_storage = Storage::new(storage_path.clone()).expect("Failed to create lock storage");
+    let (locked_tx, locked_rx) = mpsc::channel();
+
+    let handle = thread::spawn(move || {
+        lock_storage
+            .with_repository_lock(|| {
+                locked_tx
+                    .send(())
+                    .expect("Failed to signal lock acquisition");
+                thread::sleep(Duration::from_millis(250));
+                Ok::<(), Error>(())
+            })
+            .expect("Failed to hold repository lock");
+    });
+
+    locked_rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("Timed out waiting for repository lock acquisition");
+
+    let mut storage = Storage::new(storage_path).expect("Failed to create storage");
+    let mut pearl = create_collision_pearl("Repository lock", "author", 1704067200);
+    let started = Instant::now();
+    storage
+        .create_new(&mut pearl, Some(&archive_path), 2)
+        .expect("Failed to create pearl");
+
+    assert!(
+        started.elapsed() >= Duration::from_millis(200),
+        "create_new should wait for repository-level multi-file operations"
+    );
+    handle.join().expect("Repository lock thread panicked");
+}
+
+#[test]
+fn test_create_new_reserves_id_archived_while_waiting_for_repository_lock() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let storage_path = temp_dir.path().join("issues.jsonl");
+    let archive_path = temp_dir.path().join("archive.jsonl");
+    let lock_storage = Storage::new(storage_path.clone()).expect("Failed to create lock storage");
+    let archive_path_for_thread = archive_path.clone();
+    let (locked_tx, locked_rx) = mpsc::channel();
+    let (archive_tx, archive_rx) = mpsc::channel();
+
+    let handle = thread::spawn(move || {
+        lock_storage
+            .with_repository_lock(|| {
+                locked_tx
+                    .send(())
+                    .expect("Failed to signal lock acquisition");
+                archive_rx
+                    .recv_timeout(Duration::from_secs(2))
+                    .expect("Timed out waiting for archive signal");
+                let archived = create_collision_pearl("Race title", "author", 1704067200);
+                let mut archive_storage = Storage::new(archive_path_for_thread)
+                    .expect("Failed to create archive storage");
+                archive_storage
+                    .save(&archived)
+                    .expect("Failed to archive collision pearl");
+                Ok::<(), Error>(())
+            })
+            .expect("Failed to hold repository lock");
+    });
+
+    locked_rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("Timed out waiting for repository lock acquisition");
+
+    let create_thread = thread::spawn({
+        let storage_path = storage_path.clone();
+        let archive_path = archive_path.clone();
+        move || {
+            let mut storage = Storage::new(storage_path).expect("Failed to create storage");
+            let mut active = create_collision_pearl("Race title", "author", 1704067200);
+            storage
+                .create_new(&mut active, Some(&archive_path), 2)
+                .expect("Failed to create active pearl");
+            active.id
+        }
+    });
+
+    thread::sleep(Duration::from_millis(100));
+    archive_tx.send(()).expect("Failed to signal archive write");
+    let active_id = create_thread.join().expect("Create thread panicked");
+    handle.join().expect("Repository lock thread panicked");
+
+    assert_eq!(
+        active_id,
+        generate_id("Race title", "author", 1704067200, 1)
+    );
+}
+
+#[test]
+fn test_create_new_rejects_call_inside_storage_file_lock() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let storage_path = temp_dir.path().join("issues.jsonl");
+    let archive_path = temp_dir.path().join("archive.jsonl");
+    let mut storage = Storage::new(storage_path).expect("Failed to create storage");
+    let mut pearl = create_collision_pearl("Nested lock", "author", 1704067200);
+
+    let err = storage
+        .with_lock(|storage| storage.create_new(&mut pearl, Some(&archive_path), 2))
+        .expect_err("create_new inside with_lock should fail to avoid lock-order inversion");
+
+    assert!(
+        matches!(err, Error::InvalidPearl(ref message) if message.contains("storage file lock is already held")),
+        "unexpected error: {err}"
     );
 }
 

--- a/crates/pearls-mcp/src/server.rs
+++ b/crates/pearls-mcp/src/server.rs
@@ -1281,9 +1281,11 @@ mod tests {
     fn test_priority_respects_configured_max_for_create_and_update() {
         let temp = init_repo();
         let pearls_dir = temp.path().join(".pearls");
-        let mut config = Config::default();
-        config.default_priority = 1;
-        config.max_priority = 1;
+        let config = Config {
+            default_priority: 1,
+            max_priority: 1,
+            ..Default::default()
+        };
         config.save(&pearls_dir).expect("Failed to save config");
 
         let server = server_for(&temp);

--- a/crates/pearls-mcp/src/server.rs
+++ b/crates/pearls-mcp/src/server.rs
@@ -32,6 +32,9 @@ use tracing::Level;
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::fmt;
 
+const MAX_CREATE_ID_ATTEMPTS: u32 = 65_536;
+const MAX_MCP_CREATE_BATCH_SIZE: usize = 100;
+
 /// Runtime options for the MCP server.
 #[derive(Debug, Clone)]
 pub struct McpOptions {
@@ -202,15 +205,13 @@ impl PearlsMcp {
         let mut pearls = storage.load_all()?;
         if include_archived {
             if let Some(archive_storage) = repo.open_archive_storage()? {
-                if let Ok(archived) = archive_storage.load_all() {
-                    let mut archived = archived;
-                    for pearl in &mut archived {
-                        pearl
-                            .metadata
-                            .insert("archived".to_string(), serde_json::Value::Bool(true));
-                    }
-                    pearls.extend(archived);
+                let mut archived = archive_storage.load_all()?;
+                for pearl in &mut archived {
+                    pearl
+                        .metadata
+                        .insert("archived".to_string(), serde_json::Value::Bool(true));
                 }
+                pearls.extend(archived);
             }
         }
         Ok(pearls)
@@ -227,6 +228,12 @@ impl PearlsMcp {
             return Err(AppError::InvalidInput(
                 "Create request must include at least one item".to_string(),
             ));
+        }
+
+        if input.items.len() > MAX_MCP_CREATE_BATCH_SIZE {
+            return Err(AppError::InvalidInput(format!(
+                "Create request cannot include more than {MAX_MCP_CREATE_BATCH_SIZE} items"
+            )));
         }
 
         let repo = self.repo_context()?;
@@ -270,9 +277,11 @@ impl PearlsMcp {
         }
 
         let mut storage = repo.open_storage()?;
-        for pearl in &created {
-            storage.save(pearl)?;
-        }
+        storage.create_many(
+            &mut created,
+            Some(repo.archive_path()),
+            MAX_CREATE_ID_ATTEMPTS,
+        )?;
 
         Ok(CreateResult { pearls: created })
     }
@@ -1337,6 +1346,90 @@ mod tests {
                 .contains("Priority must be 0-1, got 2"),
             "Unexpected update error: {update_error}"
         );
+    }
+
+    #[test]
+    fn test_mcp_create_allocates_unique_ids_for_duplicate_inputs() {
+        let temp = init_repo();
+        let server = server_for(&temp);
+
+        let created = server
+            .create_tool(CreateInput {
+                items: vec![
+                    CreateItem {
+                        title: "Duplicate MCP".to_string(),
+                        description: None,
+                        priority: None,
+                        labels: None,
+                        author: Some("same-author".to_string()),
+                    },
+                    CreateItem {
+                        title: "Duplicate MCP".to_string(),
+                        description: None,
+                        priority: None,
+                        labels: None,
+                        author: Some("same-author".to_string()),
+                    },
+                ],
+            })
+            .expect("create failed");
+
+        assert_eq!(created.pearls.len(), 2);
+        assert_ne!(created.pearls[0].id, created.pearls[1].id);
+
+        let repo = server.repo_context().expect("repo context");
+        let storage = repo.open_storage().expect("storage");
+        let persisted = storage.load_all_strict().expect("load persisted pearls");
+        assert_eq!(persisted.len(), 2, "both MCP-created Pearls persist");
+    }
+
+    #[test]
+    fn test_mcp_create_reserves_archived_ids() {
+        let temp = init_repo();
+        let server = server_for(&temp);
+        let repo = server.repo_context().expect("repo context");
+
+        let archived =
+            pearls_core::Pearl::new("Archived MCP".to_string(), "same-author".to_string());
+        let archived_id = archived.id.clone();
+        let mut archive_storage =
+            pearls_core::Storage::new(repo.archive_path().to_path_buf()).expect("archive storage");
+        archive_storage.save(&archived).expect("save archived");
+
+        let created = server
+            .create_tool(CreateInput {
+                items: vec![CreateItem {
+                    title: "Archived MCP".to_string(),
+                    description: None,
+                    priority: None,
+                    labels: None,
+                    author: Some("same-author".to_string()),
+                }],
+            })
+            .expect("create failed");
+
+        assert_ne!(created.pearls[0].id, archived_id);
+    }
+
+    #[test]
+    fn test_mcp_create_rejects_oversized_batch() {
+        let temp = init_repo();
+        let server = server_for(&temp);
+        let items = (0..=MAX_MCP_CREATE_BATCH_SIZE)
+            .map(|idx| CreateItem {
+                title: format!("Too many {idx}"),
+                description: None,
+                priority: None,
+                labels: None,
+                author: None,
+            })
+            .collect();
+
+        let err = server
+            .create_tool(CreateInput { items })
+            .expect_err("oversized MCP create batch should fail");
+
+        assert!(err.to_string().contains("more than"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Fix create-time ID collisions by routing CLI/MCP create through locked create-only ID allocation that reserves both active and archived IDs.
- Serialize create/compact multi-file operations and make compact fail closed on malformed data or divergent archive duplicates.
- Harden storage/index reads and writes against malformed JSONL, oversized lines, duplicate IDs, symlinked managed paths/locks, and corrupt index files.

## Verification
- `cargo fmt --check`
- `cargo test -p pearls-core`
- `cargo test -p pearls-cli`
- `cargo test -p pearls-mcp`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `/tmp/repro-prl-create-id-collision.sh` with `PATH=/tmp/pearls-src-check/target/debug:$PATH` -> PASS, `count=2`
- `git diff --check`

## Review Notes
- Final blocker review found no blocking findings.
- Final security review found no blockers; only a low theoretical local TOCTOU note remains for hostile same-directory filesystem races.